### PR TITLE
Add `inspect` subcommand

### DIFF
--- a/src/command_line_args.rs
+++ b/src/command_line_args.rs
@@ -309,6 +309,15 @@ pub enum SubCommand {
 
 impl SubCommand {
     fn new(args: &mut noargs::RawArgs) -> noargs::Result<Option<Self>> {
+        if args
+            .remaining_args()
+            .find(|a| matches!(a.1, "inspect"))
+            .is_none()
+        {
+            // サブコマンドなし
+            return Ok(None);
+        }
+
         if noargs::cmd("inspect")
             .doc("録画ファイルの情報を取得する")
             .take(args)
@@ -322,8 +331,7 @@ impl SubCommand {
                     .then(|a| a.value().parse())?,
             }))
         } else {
-            // サブコマンドなし
-            Ok(None)
+            unreachable!()
         }
     }
 }

--- a/src/command_line_args.rs
+++ b/src/command_line_args.rs
@@ -25,6 +25,7 @@ pub struct Args {
     pub show_progress_bar: bool,
     pub layout: Option<PathBuf>,
     pub cpu_cores: Option<usize>,
+    pub sub_command: Option<SubCommand>,
 }
 
 impl Args {
@@ -256,7 +257,14 @@ NOTE: `--layout` 引数が指定されている場合にはこの引数は無視
             eprintln!("[WARN] `--h264-encoder` is obsolete\n");
         }
 
-        if version.is_none() && in_metadata_file.is_none() && layout.is_none() && !codec_engines {
+        let sub_command = SubCommand::new(&mut args)?;
+
+        if version.is_none()
+            && in_metadata_file.is_none()
+            && layout.is_none()
+            && !codec_engines
+            && sub_command.is_none()
+        {
             // 最低限必要な引数が指定されていない場合にはヘルプを表示する
             args.metadata_mut().help_mode = true;
         }
@@ -282,11 +290,40 @@ NOTE: `--layout` 引数が指定されている場合にはこの引数は無視
             verbose,
             cpu_cores,
             out_stats_file,
+            sub_command,
             help: args.finish()?,
         })
     }
 
     pub fn get_help_or_version(&self) -> Option<&String> {
         self.help.as_ref().or(self.version.as_ref())
+    }
+}
+
+// TODO(sile): -h の時のサブコマンドのヘルプの見せ方は改善する
+//             (e.g., サブコマンドを指定しているかどうかで引数処理を大元で分岐させる）
+#[derive(Debug, Clone)]
+pub enum SubCommand {
+    Inspect { input_file: PathBuf },
+}
+
+impl SubCommand {
+    fn new(args: &mut noargs::RawArgs) -> noargs::Result<Option<Self>> {
+        if noargs::cmd("inspect")
+            .doc("録画ファイルの情報を取得する")
+            .take(args)
+            .is_present()
+        {
+            Ok(Some(Self::Inspect {
+                input_file: noargs::arg("INPUT_FILE")
+                    .example("/path/to/archive.mp4")
+                    .doc("情報取得対象の録画ファイル(.mp4|.webm)")
+                    .take(args)
+                    .then(|a| a.value().parse())?,
+            }))
+        } else {
+            // サブコマンドなし
+            Ok(None)
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ pub mod reader_webm;
 pub mod runner;
 pub mod source;
 pub mod stats;
+pub mod subcommand_inspect;
 pub mod types;
 pub mod video;
 pub mod video_h264;

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,11 @@ fn main() -> noargs::Result<()> {
     };
     Logger::init(log_level)?;
 
+    if let Some(text) = args.get_help_or_version() {
+        print!("{text}");
+        return Ok(());
+    }
+
     match args.sub_command {
         Some(SubCommand::Inspect { input_file }) => hisui::subcommand_inspect::run(input_file)?,
         None => Runner::new(args).run()?,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,8 @@
-use hisui::{command_line_args::Args, logger::Logger, runner::Runner};
+use hisui::{
+    command_line_args::{Args, SubCommand},
+    logger::Logger,
+    runner::Runner,
+};
 
 fn main() -> noargs::Result<()> {
     let args = Args::parse(std::env::args())?;
@@ -11,6 +15,9 @@ fn main() -> noargs::Result<()> {
     };
     Logger::init(log_level)?;
 
-    Runner::new(args).run()?;
+    match args.sub_command {
+        Some(SubCommand::Inspect { input_file }) => hisui::subcommand_inspect::run(input_file)?,
+        None => Runner::new(args).run()?,
+    }
     Ok(())
 }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -180,6 +180,15 @@ pub enum ContainerFormat {
     Mp4,
 }
 
+impl nojson::DisplayJson for ContainerFormat {
+    fn fmt(&self, f: &mut nojson::JsonFormatter<'_, '_>) -> std::fmt::Result {
+        match self {
+            ContainerFormat::Webm => f.string("webm"),
+            ContainerFormat::Mp4 => f.string("mp4"),
+        }
+    }
+}
+
 impl<'text> nojson::FromRawJsonValue<'text> for ContainerFormat {
     fn from_raw_json_value(
         value: nojson::RawJsonValue<'text, '_>,

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -32,11 +32,6 @@ impl Runner {
     }
 
     pub fn run(&mut self) -> orfail::Result<()> {
-        if let Some(text) = self.args.get_help_or_version() {
-            print!("{text}");
-            return Ok(());
-        }
-
         if self.args.codec_engines {
             // 利用可能なエンジンやコーデックを表示して終了する
             self.show_codec_engines().or_fail()?;

--- a/src/subcommand_inspect.rs
+++ b/src/subcommand_inspect.rs
@@ -28,7 +28,7 @@ pub fn run<P: AsRef<Path>>(input_file_path: P) -> orfail::Result<()> {
 
     let dummy_source_id = SourceId::new("inspect"); // 使われないのでなんでもいい
 
-    let (video_reader, audio_reader) = match format {
+    let (audio_reader, video_reader) = match format {
         ContainerFormat::Webm => {
             let audio = AudioReader::Webm(
                 WebmAudioReader::new(dummy_source_id.clone(), &input_file_path).or_fail()?,
@@ -48,6 +48,16 @@ pub fn run<P: AsRef<Path>>(input_file_path: P) -> orfail::Result<()> {
             (audio, video)
         }
     };
+
+    for sample in audio_reader {
+        let sample = sample.or_fail()?;
+        dbg!(sample.timestamp);
+    }
+
+    for sample in video_reader {
+        let sample = sample.or_fail()?;
+        dbg!(sample.timestamp);
+    }
 
     Ok(())
 }

--- a/src/subcommand_inspect.rs
+++ b/src/subcommand_inspect.rs
@@ -78,6 +78,7 @@ pub fn run<P: AsRef<Path>>(input_file_path: P) -> orfail::Result<()> {
             timestamp: sample.timestamp,
             duration: sample.duration,
             data_size: sample.data.len(),
+            keyframe: sample.keyframe,
         });
     }
 
@@ -174,6 +175,7 @@ struct VideoSampleInfo {
     timestamp: Duration,
     duration: Duration,
     data_size: usize,
+    keyframe: bool,
 }
 
 impl nojson::DisplayJson for VideoSampleInfo {
@@ -183,6 +185,7 @@ impl nojson::DisplayJson for VideoSampleInfo {
             f.member("timestamp_us", self.timestamp.as_micros())?;
             f.member("duration_us", self.duration.as_micros())?;
             f.member("data_size", self.data_size)?;
+            f.member("keyframe", self.keyframe)?;
             Ok(())
         })?;
         f.set_indent_size(2);

--- a/src/subcommand_inspect.rs
+++ b/src/subcommand_inspect.rs
@@ -1,5 +1,5 @@
 use std::path::Path;
 
-pub fn run<P: AsRef<Path>>(input_file_path: P) -> orfail::Result<()> {
+pub fn run<P: AsRef<Path>>(_input_file_path: P) -> orfail::Result<()> {
     todo!()
 }

--- a/src/subcommand_inspect.rs
+++ b/src/subcommand_inspect.rs
@@ -1,5 +1,53 @@
 use std::path::Path;
 
-pub fn run<P: AsRef<Path>>(_input_file_path: P) -> orfail::Result<()> {
+use crate::{
+    metadata::{ContainerFormat, SourceId},
+    reader::{AudioReader, VideoReader},
+    reader_mp4::{Mp4AudioReader, Mp4VideoReader},
+    reader_webm::{WebmAudioReader, WebmVideoReader},
+};
+
+use orfail::OrFail;
+
+pub fn run<P: AsRef<Path>>(input_file_path: P) -> orfail::Result<()> {
+    let format = match input_file_path
+        .as_ref()
+        .extension()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .as_ref()
+    {
+        "mp4" => ContainerFormat::Mp4,
+        "webm" => ContainerFormat::Webm,
+        ext => {
+            return Err(orfail::Failure::new(format!(
+                "unsupported container format: {ext}"
+            )))
+        }
+    };
+
+    let dummy_source_id = SourceId::new("inspect"); // 使われないのでなんでもいい
+
+    let (video_reader, audio_reader) = match format {
+        ContainerFormat::Webm => {
+            let audio = AudioReader::Webm(
+                WebmAudioReader::new(dummy_source_id.clone(), &input_file_path).or_fail()?,
+            );
+            let video = VideoReader::Webm(
+                WebmVideoReader::new(dummy_source_id.clone(), &input_file_path).or_fail()?,
+            );
+            (audio, video)
+        }
+        ContainerFormat::Mp4 => {
+            let audio = AudioReader::Mp4(
+                Mp4AudioReader::new(dummy_source_id.clone(), &input_file_path).or_fail()?,
+            );
+            let video = VideoReader::Mp4(
+                Mp4VideoReader::new(dummy_source_id.clone(), &input_file_path).or_fail()?,
+            );
+            (audio, video)
+        }
+    };
+
     Ok(())
 }

--- a/src/subcommand_inspect.rs
+++ b/src/subcommand_inspect.rs
@@ -1,5 +1,5 @@
 use std::path::Path;
 
 pub fn run<P: AsRef<Path>>(_input_file_path: P) -> orfail::Result<()> {
-    todo!()
+    Ok(())
 }

--- a/src/subcommand_inspect.rs
+++ b/src/subcommand_inspect.rs
@@ -80,8 +80,6 @@ pub fn run<P: AsRef<Path>>(input_file_path: P) -> orfail::Result<()> {
         path: input_file_path.as_ref().to_path_buf(),
         format,
         audio_codec,
-        audio_duration: audio_samples.iter().map(|s| s.duration).sum(),
-        audio_sample_count: audio_samples.len(),
         audio_samples,
         video_codec,
     };
@@ -102,8 +100,6 @@ struct FileInfo {
     path: PathBuf,
     format: ContainerFormat,
     audio_codec: Option<CodecName>,
-    audio_duration: Duration,
-    audio_sample_count: usize,
     audio_samples: Vec<AudioSampleInfo>,
     video_codec: Option<CodecName>,
 }
@@ -115,8 +111,15 @@ impl nojson::DisplayJson for FileInfo {
             f.member("format", &self.format)?;
             if let Some(c) = self.audio_codec {
                 f.member("audio_codec", c)?;
-                f.member("audio_duration_us", self.audio_duration.as_micros())?;
-                f.member("audio_sample_count", self.audio_sample_count)?;
+                f.member(
+                    "audio_duration_us",
+                    self.audio_samples
+                        .iter()
+                        .map(|s| s.duration)
+                        .sum::<Duration>()
+                        .as_micros(),
+                )?;
+                f.member("audio_sample_count", self.audio_samples.len())?;
                 f.member("audio_samples", &self.audio_samples)?;
             }
             if let Some(c) = self.video_codec {

--- a/src/subcommand_inspect.rs
+++ b/src/subcommand_inspect.rs
@@ -1,0 +1,5 @@
+use std::path::Path;
+
+pub fn run<P: AsRef<Path>>(input_file_path: P) -> orfail::Result<()> {
+    todo!()
+}

--- a/src/subcommand_inspect.rs
+++ b/src/subcommand_inspect.rs
@@ -80,8 +80,10 @@ pub fn run<P: AsRef<Path>>(input_file_path: P) -> orfail::Result<()> {
         path: input_file_path.as_ref().to_path_buf(),
         format,
         audio_codec,
-        video_codec,
+        audio_duration: audio_samples.iter().map(|s| s.duration).sum(),
+        audio_sample_count: audio_samples.len(),
         audio_samples,
+        video_codec,
     };
     println!(
         "{}",
@@ -100,9 +102,10 @@ struct FileInfo {
     path: PathBuf,
     format: ContainerFormat,
     audio_codec: Option<CodecName>,
-    video_codec: Option<CodecName>,
-    // TODO: sample_count, duration
+    audio_duration: Duration,
+    audio_sample_count: usize,
     audio_samples: Vec<AudioSampleInfo>,
+    video_codec: Option<CodecName>,
 }
 
 impl nojson::DisplayJson for FileInfo {
@@ -112,12 +115,12 @@ impl nojson::DisplayJson for FileInfo {
             f.member("format", &self.format)?;
             if let Some(c) = self.audio_codec {
                 f.member("audio_codec", c)?;
+                f.member("audio_duration_us", self.audio_duration.as_micros())?;
+                f.member("audio_sample_count", self.audio_sample_count)?;
+                f.member("audio_samples", &self.audio_samples)?;
             }
             if let Some(c) = self.video_codec {
                 f.member("video_codec", c)?;
-            }
-            if !self.audio_samples.is_empty() {
-                f.member("audio_samples", &self.audio_samples)?;
             }
             Ok(())
         })


### PR DESCRIPTION
This pull request introduces a new subcommand system to the application, starting with an `inspect` subcommand for analyzing video files. The changes include modifications to the command-line argument parser, addition of a new `SubCommand` enum, and implementation of the `inspect` subcommand logic. Additionally, JSON serialization support has been added for certain types to facilitate structured output.

### Subcommand System Implementation:

* **`SubCommand` Enum and Parsing**: Added a `SubCommand` enum to represent subcommands, starting with `Inspect { input_file: PathBuf }`. Updated the `Args` struct and parsing logic to support subcommands. [[1]](diffhunk://#diff-4c9702dae802d6267efb86b5af5b536f88dd04b36b21cc52812436e4aa67fb2cR28) [[2]](diffhunk://#diff-4c9702dae802d6267efb86b5af5b536f88dd04b36b21cc52812436e4aa67fb2cL259-R267) [[3]](diffhunk://#diff-4c9702dae802d6267efb86b5af5b536f88dd04b36b21cc52812436e4aa67fb2cR302-R337)
* **`inspect` Subcommand Logic**: Implemented the `inspect` subcommand in a new `src/subcommand_inspect.rs` file. This subcommand extracts metadata (e.g., codecs, sample information) from video files and outputs it in JSON format.

### Integration with Main Application:

* **Main Function Update**: Modified `main.rs` to handle subcommands. If the `inspect` subcommand is invoked, its logic is executed; otherwise, the original `Runner` logic is used. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL1-R5) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL14-R26)
* **Removed Redundant Help/Version Logic**: Refactored `Runner` to delegate help/version handling to the updated `Args` logic.

### JSON Serialization Enhancements:

* **`ContainerFormat` JSON Support**: Added `nojson::DisplayJson` implementation for `ContainerFormat` to serialize it as JSON.
* **New JSON Structs**: Defined several structs (`FileInfo`, `AudioSampleInfo`, `VideoSampleInfo`, etc.) with `nojson::DisplayJson` implementations to format `inspect` subcommand output.

### Codebase Organization:

* **New Module**: Added `subcommand_inspect` as a new module in `src/lib.rs`.