### PR TITLE
Add `--decode` flag for `inspect` subcommand

### DIFF
--- a/src/command_line_args.rs
+++ b/src/command_line_args.rs
@@ -304,7 +304,11 @@ NOTE: `--layout` 引数が指定されている場合にはこの引数は無視
 //             (e.g., サブコマンドを指定しているかどうかで引数処理を大元で分岐させる）
 #[derive(Debug, Clone)]
 pub enum SubCommand {
-    Inspect { input_file: PathBuf, decode: bool },
+    Inspect {
+        input_file: PathBuf,
+        decode: bool,
+        openh264: Option<PathBuf>,
+    },
 }
 
 impl SubCommand {
@@ -328,6 +332,11 @@ impl SubCommand {
                     .doc("指定された場合にはデコードまで行う")
                     .take(args)
                     .is_present(),
+                openh264: noargs::opt("openh264")
+                    .ty("PATH")
+                    .doc("OpenH264 の共有ライブラリのパス")
+                    .take(args)
+                    .present_and_then(|a| a.value().parse())?,
                 input_file: noargs::arg("INPUT_FILE")
                     .example("/path/to/archive.mp4")
                     .doc("情報取得対象の録画ファイル(.mp4|.webm)")

--- a/src/command_line_args.rs
+++ b/src/command_line_args.rs
@@ -304,7 +304,7 @@ NOTE: `--layout` 引数が指定されている場合にはこの引数は無視
 //             (e.g., サブコマンドを指定しているかどうかで引数処理を大元で分岐させる）
 #[derive(Debug, Clone)]
 pub enum SubCommand {
-    Inspect { input_file: PathBuf },
+    Inspect { input_file: PathBuf, decode: bool },
 }
 
 impl SubCommand {
@@ -324,6 +324,10 @@ impl SubCommand {
             .is_present()
         {
             Ok(Some(Self::Inspect {
+                decode: noargs::flag("decode")
+                    .doc("指定された場合にはデコードまで行う")
+                    .take(args)
+                    .is_present(),
                 input_file: noargs::arg("INPUT_FILE")
                     .example("/path/to/archive.mp4")
                     .doc("情報取得対象の録画ファイル(.mp4|.webm)")

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,9 @@ fn main() -> noargs::Result<()> {
     }
 
     match args.sub_command {
-        Some(SubCommand::Inspect { input_file }) => hisui::subcommand_inspect::run(input_file)?,
+        Some(SubCommand::Inspect { input_file, decode }) => {
+            hisui::subcommand_inspect::run(input_file, decode)?
+        }
         None => Runner::new(args).run()?,
     }
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,9 +21,11 @@ fn main() -> noargs::Result<()> {
     }
 
     match args.sub_command {
-        Some(SubCommand::Inspect { input_file, decode }) => {
-            hisui::subcommand_inspect::run(input_file, decode)?
-        }
+        Some(SubCommand::Inspect {
+            input_file,
+            decode,
+            openh264,
+        }) => hisui::subcommand_inspect::run(input_file, decode, openh264)?,
         None => Runner::new(args).run()?,
     }
     Ok(())

--- a/src/subcommand_inspect.rs
+++ b/src/subcommand_inspect.rs
@@ -16,7 +16,11 @@ use crate::{
 
 use orfail::OrFail;
 
-pub fn run<P: AsRef<Path>>(input_file_path: P, decode: bool) -> orfail::Result<()> {
+pub fn run<P: AsRef<Path>>(
+    input_file_path: P,
+    decode: bool,
+    _openh264: Option<PathBuf>,
+) -> orfail::Result<()> {
     let format = match input_file_path
         .as_ref()
         .extension()

--- a/src/subcommand_inspect.rs
+++ b/src/subcommand_inspect.rs
@@ -15,7 +15,7 @@ use crate::{
 
 use orfail::OrFail;
 
-pub fn run<P: AsRef<Path>>(input_file_path: P) -> orfail::Result<()> {
+pub fn run<P: AsRef<Path>>(input_file_path: P, _decode: bool) -> orfail::Result<()> {
     let format = match input_file_path
         .as_ref()
         .extension()


### PR DESCRIPTION
This pull request introduces enhancements to the `Inspect` subcommand in the codebase, enabling optional decoding of audio and video files and providing additional metadata for decoded samples. Key changes include updates to the `SubCommand` enum, modifications to the `run` function in `subcommand_inspect.rs`, and extensions to the `AudioSampleInfo` and `VideoSampleInfo` structs for decoded data attributes.

### Enhancements to the `Inspect` Subcommand:

#### Command-line argument updates:
* Added `decode` flag to enable decoding and `openh264` option to specify the OpenH264 library path in the `Inspect` subcommand. (`src/command_line_args.rs`, [[1]](diffhunk://#diff-4c9702dae802d6267efb86b5af5b536f88dd04b36b21cc52812436e4aa67fb2cL307-R311) [[2]](diffhunk://#diff-4c9702dae802d6267efb86b5af5b536f88dd04b36b21cc52812436e4aa67fb2cR331-R339)

#### Decoding functionality:
* Updated `subcommand_inspect::run` to handle optional decoding of audio and video files using `AudioDecoder` and `VideoDecoder`, and to process OpenH264 library paths if provided. (`src/subcommand_inspect.rs`, [[1]](diffhunk://#diff-5a78755465e1547b64af3fbb0d02aff50e1696bcde09ee710de00b47fe62d7deR7-R25) [[2]](diffhunk://#diff-5a78755465e1547b64af3fbb0d02aff50e1696bcde09ee710de00b47fe62d7deR67-R137)

#### Metadata extensions:
* Enhanced `AudioSampleInfo` and `VideoSampleInfo` structs to include decoded data size, and for video samples, additional attributes for width and height. Added methods to update these attributes after decoding. (`src/subcommand_inspect.rs`, [[1]](diffhunk://#diff-5a78755465e1547b64af3fbb0d02aff50e1696bcde09ee710de00b47fe62d7deR216) [[2]](diffhunk://#diff-5a78755465e1547b64af3fbb0d02aff50e1696bcde09ee710de00b47fe62d7deR243-R253)

#### JSON output improvements:
* Modified JSON serialization for `AudioSampleInfo` and `VideoSampleInfo` to include new decoded data attributes in the output. (`src/subcommand_inspect.rs`, [[1]](diffhunk://#diff-5a78755465e1547b64af3fbb0d02aff50e1696bcde09ee710de00b47fe62d7deR226-R228) [[2]](diffhunk://#diff-5a78755465e1547b64af3fbb0d02aff50e1696bcde09ee710de00b47fe62d7deR270-R278)

These changes collectively improve the functionality and output of the `Inspect` subcommand, making it more versatile and informative for users.