### PR TITLE
入力映像のタイムスタンプが大幅に飛んだ場合に対応する

### DIFF
--- a/src/mixer_video.rs
+++ b/src/mixer_video.rs
@@ -22,6 +22,7 @@ pub struct VideoMixerThread {
     current_frames: HashMap<SourceId, VideoFrame>,
     eos_source_ids: HashSet<SourceId>,
     last_mixed_frame: Option<VideoFrame>,
+    last_input_update_time: Duration,
     stats: VideoMixerStats,
 }
 
@@ -47,6 +48,7 @@ impl VideoMixerThread {
             current_frames: HashMap::new(),
             eos_source_ids: HashSet::new(),
             last_mixed_frame: None,
+            last_input_update_time: Duration::ZERO,
             stats: VideoMixerStats {
                 output_video_resolution: VideoResolution {
                     width: resolution.width().get(),
@@ -137,6 +139,7 @@ impl VideoMixerThread {
                 input.source_id = Some(source_id.clone());
             }
             self.current_frames.insert(source_id, frame);
+            self.last_input_update_time = now;
             self.stats.total_input_video_frame_count += 1;
         }
         Ok(())
@@ -166,6 +169,8 @@ impl VideoMixerThread {
                 // まだ表示時刻に収まっている
                 return true;
             }
+
+            self.last_input_update_time = now;
             false
         });
 

--- a/src/mixer_video.rs
+++ b/src/mixer_video.rs
@@ -120,14 +120,14 @@ impl VideoMixerThread {
     fn next_input_timestamp(&self) -> Duration {
         self.frames_to_timestamp(
             self.stats.total_output_video_frame_count
-                + self.stats.total_merged_video_frame_count
+                + self.stats.total_extended_video_frame_count
                 + self.stats.total_trimmed_video_frame_count,
         )
     }
 
     fn next_output_timestamp(&self) -> Duration {
         self.frames_to_timestamp(
-            self.stats.total_output_video_frame_count + self.stats.total_merged_video_frame_count,
+            self.stats.total_output_video_frame_count + self.stats.total_extended_video_frame_count,
         )
     }
 
@@ -135,7 +135,7 @@ impl VideoMixerThread {
         // 丸め誤差が蓄積しないように次のフレームのタイスタンプとの差をとる
         self.frames_to_timestamp(
             self.stats.total_output_video_frame_count
-                + self.stats.total_merged_video_frame_count
+                + self.stats.total_extended_video_frame_count
                 + 1,
         ) - self.next_output_timestamp()
     }
@@ -224,7 +224,7 @@ impl VideoMixerThread {
                 let last_frame = self.last_mixed_frame.as_mut().expect("infallible");
 
                 last_frame.duration += duration;
-                self.stats.total_merged_video_frame_count += 1;
+                self.stats.total_extended_video_frame_count += 1;
                 self.stats.total_output_video_frame_seconds += duration; // 出力フレーム数は増えないけど尺は伸びる
 
                 continue;

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -222,6 +222,9 @@ pub struct VideoMixerStats {
     /// 出力から除去された映像フレームの合計数
     pub total_trimmed_video_frame_count: u64,
 
+    /// 合成を省略して前フレームに統合されたフレームの数
+    pub total_merged_video_frame_count: u64,
+
     /// 合成処理部分に掛かった時間
     pub total_processing_seconds: Seconds,
 
@@ -249,6 +252,10 @@ impl nojson::DisplayJson for VideoMixerStats {
             f.member(
                 "total_trimmed_video_frame_count",
                 &self.total_trimmed_video_frame_count,
+            )?;
+            f.member(
+                "total_merged_video_frame_count",
+                &self.total_merged_video_frame_count,
             )?;
             f.member("total_processing_seconds", &self.total_processing_seconds)?;
             f.member("error", &self.error)?;

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -222,8 +222,8 @@ pub struct VideoMixerStats {
     /// 出力から除去された映像フレームの合計数
     pub total_trimmed_video_frame_count: u64,
 
-    /// 合成を省略して前フレームに統合されたフレームの数
-    pub total_merged_video_frame_count: u64,
+    /// 合成を省略して前フレームの尺を延長したフレームの数
+    pub total_extended_video_frame_count: u64,
 
     /// 合成処理部分に掛かった時間
     pub total_processing_seconds: Seconds,
@@ -254,8 +254,8 @@ impl nojson::DisplayJson for VideoMixerStats {
                 &self.total_trimmed_video_frame_count,
             )?;
             f.member(
-                "total_merged_video_frame_count",
-                &self.total_merged_video_frame_count,
+                "total_extended_video_frame_count",
+                &self.total_extended_video_frame_count,
             )?;
             f.member("total_processing_seconds", &self.total_processing_seconds)?;
             f.member("error", &self.error)?;


### PR DESCRIPTION
This pull request introduces enhancements to the `VideoMixerThread` in `src/mixer_video.rs` to handle scenarios where input frames are not updated for extended periods. It includes logic to adjust frame durations or raise errors based on thresholds, updates statistics tracking, and refines timestamp calculations. Additionally, new metrics for extended frame counts are added to `VideoMixerStats` in `src/stats.rs`.

### Enhancements to input frame handling:
* Added `TIMESTAMP_GAP_THRESHOLD` and `TIMESTAMP_GAP_ERROR_THRESHOLD` constants to define thresholds for handling input frame update delays.
* Updated `next_output_frame` logic to adjust the duration of the last mixed frame when input updates are delayed, preventing excessive frame generation.
* Introduced tracking of the last input update time (`last_input_update_time`) and logic to update it during input processing. [[1]](diffhunk://#diff-6cc9b92954d6f8a7bbfd5d42c09fad91e0500b172a3379ee3e10c668406cfb8eR161-R168) [[2]](diffhunk://#diff-6cc9b92954d6f8a7bbfd5d42c09fad91e0500b172a3379ee3e10c668406cfb8eR192-R193)

### Improvements to timestamp calculations:
* Refined timestamp calculations in `next_input_timestamp`, `next_output_timestamp`, and `next_output_duration` to account for extended frame durations.

### Updates to statistics tracking:
* Added `total_extended_video_frame_count` to `VideoMixerStats` to track frames with extended durations and updated JSON serialization to include this metric. [[1]](diffhunk://#diff-0e692e133bf2b1fcf6a0d97c4db8aaafe11090170dc1c4d1a655cd143fcd814aR225-R227) [[2]](diffhunk://#diff-0e692e133bf2b1fcf6a0d97c4db8aaafe11090170dc1c4d1a655cd143fcd814aR256-R259)