### PR TITLE
Add `list-codes` subcommand

### DIFF
--- a/src/command_line_args.rs
+++ b/src/command_line_args.rs
@@ -19,7 +19,7 @@ pub struct Args {
     pub out_aac_bit_rate: NonZeroUsize,
     pub openh264: Option<PathBuf>,
     pub audio_only: bool,
-    pub codec_engines: bool,
+    pub codec_engines: bool, // TODO: 削除する
     pub show_progress_bar: bool,
     pub layout: Option<PathBuf>,
     pub cpu_cores: Option<usize>,

--- a/src/command_line_args.rs
+++ b/src/command_line_args.rs
@@ -193,7 +193,7 @@ NOTE: `--layout` 引数が指定されている場合にはこの引数は無視
             // まだロガーのセットアップが行われていないので eprintln!() で直接出力する
             // （以降も同様）
             eprintln!(
-                "[WARN] `--video-codec-engines` is obsolete (please use `--codec-engines` instead)\n"
+                "[WARN] `--video-codec-engines` is obsolete (please use `list-codecs` command instead)\n"
             );
         }
         if noargs::opt("mp4-muxer")

--- a/src/command_line_args.rs
+++ b/src/command_line_args.rs
@@ -19,7 +19,6 @@ pub struct Args {
     pub out_aac_bit_rate: NonZeroUsize,
     pub openh264: Option<PathBuf>,
     pub audio_only: bool,
-    pub codec_engines: bool, // TODO: 削除する
     pub show_progress_bar: bool,
     pub layout: Option<PathBuf>,
     pub cpu_cores: Option<usize>,
@@ -27,10 +26,6 @@ pub struct Args {
 
 impl Args {
     pub fn parse(mut args: noargs::RawArgs) -> noargs::Result<Self> {
-        let codec_engines = noargs::flag("codec-engines")
-            .doc("利用可能なエンコーダ・デコーダの一覧を JSON 形式で表示します")
-            .take(&mut args)
-            .is_present();
         let in_metadata_file = noargs::opt("in-metadata-file")
             .short('f')
             .ty("PATH")
@@ -234,13 +229,12 @@ NOTE: `--layout` 引数が指定されている場合にはこの引数は無視
             eprintln!("[WARN] `--h264-encoder` is obsolete\n");
         }
 
-        if in_metadata_file.is_none() && layout.is_none() && !codec_engines {
+        if in_metadata_file.is_none() && layout.is_none() {
             // 最低限必要な引数が指定されていない場合にはヘルプを表示する
             args.metadata_mut().help_mode = true;
         }
 
         Ok(Self {
-            codec_engines,
             in_metadata_file,
             layout,
             out_file,

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -30,6 +30,15 @@ impl AudioDecoder {
         }
     }
 
+    pub fn get_engines(codec: CodecName) -> Vec<EngineName> {
+        match codec {
+            CodecName::Aac => vec![],
+            CodecName::Opus => vec![EngineName::Opus],
+            _ => unreachable!(),
+        }
+    }
+
+    // TODO: remove
     pub fn update_codec_engines(engines: &mut CodecEngines) {
         engines.insert_decoder(CodecName::Opus, EngineName::Opus);
     }
@@ -58,6 +67,36 @@ impl VideoDecoder {
         Self::Initial { options }
     }
 
+    pub fn get_engines(codec: CodecName, is_openh264_available: bool) -> Vec<EngineName> {
+        let mut engines = Vec::new();
+        match codec {
+            CodecName::Vp8 | CodecName::Vp9 => {
+                engines.push(EngineName::Libvpx);
+            }
+            CodecName::H264 => {
+                if is_openh264_available {
+                    engines.push(EngineName::Openh264);
+                }
+                #[cfg(target_os = "macos")]
+                {
+                    engines.push(EngineName::VideoToolbox);
+                }
+            }
+            CodecName::H265 => {
+                #[cfg(target_os = "macos")]
+                {
+                    engines.push(EngineName::VideoToolbox);
+                }
+            }
+            CodecName::Av1 => {
+                engines.push(EngineName::Dav1d);
+            }
+            _ => unreachable!(),
+        }
+        engines
+    }
+
+    // TODO: delete
     pub fn update_codec_engines(engines: &mut CodecEngines, options: VideoDecoderOptions) {
         engines.insert_decoder(CodecName::Vp8, EngineName::Libvpx);
         engines.insert_decoder(CodecName::Vp9, EngineName::Libvpx);

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -10,7 +10,7 @@ use crate::{
     decoder_openh264::Openh264Decoder,
     decoder_opus::OpusDecoder,
     stats::VideoDecoderStats,
-    types::{CodecEngines, CodecName, EngineName},
+    types::{CodecName, EngineName},
     video::{VideoFormat, VideoFrame},
 };
 
@@ -36,11 +36,6 @@ impl AudioDecoder {
             CodecName::Opus => vec![EngineName::Opus],
             _ => unreachable!(),
         }
-    }
-
-    // TODO: remove
-    pub fn update_codec_engines(engines: &mut CodecEngines) {
-        engines.insert_decoder(CodecName::Opus, EngineName::Opus);
     }
 }
 
@@ -94,23 +89,6 @@ impl VideoDecoder {
             _ => unreachable!(),
         }
         engines
-    }
-
-    // TODO: delete
-    pub fn update_codec_engines(engines: &mut CodecEngines, options: VideoDecoderOptions) {
-        engines.insert_decoder(CodecName::Vp8, EngineName::Libvpx);
-        engines.insert_decoder(CodecName::Vp9, EngineName::Libvpx);
-        engines.insert_decoder(CodecName::Av1, EngineName::Dav1d);
-
-        if options.openh264_lib.is_some() {
-            engines.insert_decoder(CodecName::H264, EngineName::Openh264);
-        }
-
-        #[cfg(target_os = "macos")]
-        {
-            engines.insert_decoder(CodecName::H264, EngineName::VideoToolbox);
-            engines.insert_decoder(CodecName::H265, EngineName::VideoToolbox);
-        }
     }
 
     pub fn decode(

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -137,7 +137,6 @@ impl VideoEncoder {
                 engines.push(EngineName::Libvpx);
             }
             CodecName::H264 => {
-                engines.push(EngineName::Openh264);
                 if is_openh264_available {
                     engines.push(EngineName::Openh264);
                 }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -12,14 +12,13 @@ use crate::encoder_video_toolbox::VideoToolboxEncoder;
 use crate::{
     audio::AudioData,
     channel::{self, ErrorFlag},
-    decoder::VideoDecoderOptions,
     encoder_libvpx::LibvpxEncoder,
     encoder_openh264::Openh264Encoder,
     encoder_opus::OpusEncoder,
     encoder_svt_av1::SvtAv1Encoder,
     layout::Layout,
     stats::{AudioEncoderStats, EncoderStats, Seconds, SharedStats, VideoEncoderStats},
-    types::{CodecEngines, CodecName, EngineName},
+    types::{CodecName, EngineName},
     video::VideoFrame,
 };
 
@@ -107,17 +106,6 @@ impl AudioEncoder {
         }
         engines
     }
-
-    // TODO: delete
-    pub fn update_codec_engines(engines: &mut CodecEngines) {
-        engines.insert_encoder(CodecName::Opus, EngineName::Opus);
-
-        #[cfg(feature = "fdk-aac")]
-        engines.insert_encoder(CodecName::Aac, EngineName::FdkAac);
-
-        #[cfg(target_os = "macos")]
-        engines.insert_encoder(CodecName::Aac, EngineName::AudioToobox);
-    }
 }
 
 #[derive(Debug)]
@@ -130,52 +118,6 @@ pub enum VideoEncoder {
 }
 
 impl VideoEncoder {
-    pub fn get_engines(codec: CodecName, is_openh264_available: bool) -> Vec<EngineName> {
-        let mut engines = Vec::new();
-        match codec {
-            CodecName::Vp8 | CodecName::Vp9 => {
-                engines.push(EngineName::Libvpx);
-            }
-            CodecName::H264 => {
-                if is_openh264_available {
-                    engines.push(EngineName::Openh264);
-                }
-                #[cfg(target_os = "macos")]
-                {
-                    engines.push(EngineName::VideoToolbox);
-                }
-            }
-            CodecName::H265 => {
-                #[cfg(target_os = "macos")]
-                {
-                    engines.push(EngineName::VideoToolbox);
-                }
-            }
-            CodecName::Av1 => {
-                engines.push(EngineName::SvtAv1);
-            }
-            _ => unreachable!(),
-        }
-        engines
-    }
-
-    // TODO: delete
-    pub fn update_codec_engines(engines: &mut CodecEngines, options: VideoDecoderOptions) {
-        engines.insert_encoder(CodecName::Vp8, EngineName::Libvpx);
-        engines.insert_encoder(CodecName::Vp9, EngineName::Libvpx);
-        engines.insert_encoder(CodecName::Av1, EngineName::SvtAv1);
-
-        if options.openh264_lib.is_some() {
-            engines.insert_encoder(CodecName::H264, EngineName::Openh264);
-        }
-
-        #[cfg(target_os = "macos")]
-        {
-            engines.insert_encoder(CodecName::H264, EngineName::VideoToolbox);
-            engines.insert_encoder(CodecName::H265, EngineName::VideoToolbox);
-        }
-    }
-
     pub fn new_vp8(
         layout: &Layout,
         cq_level: usize,
@@ -266,6 +208,35 @@ impl VideoEncoder {
             #[cfg(target_os = "macos")]
             Self::VideoToolbox(encoder) => encoder.codec(),
         }
+    }
+
+    pub fn get_engines(codec: CodecName, is_openh264_available: bool) -> Vec<EngineName> {
+        let mut engines = Vec::new();
+        match codec {
+            CodecName::Vp8 | CodecName::Vp9 => {
+                engines.push(EngineName::Libvpx);
+            }
+            CodecName::H264 => {
+                if is_openh264_available {
+                    engines.push(EngineName::Openh264);
+                }
+                #[cfg(target_os = "macos")]
+                {
+                    engines.push(EngineName::VideoToolbox);
+                }
+            }
+            CodecName::H265 => {
+                #[cfg(target_os = "macos")]
+                {
+                    engines.push(EngineName::VideoToolbox);
+                }
+            }
+            CodecName::Av1 => {
+                engines.push(EngineName::SvtAv1);
+            }
+            _ => unreachable!(),
+        }
+        engines
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ pub mod source;
 pub mod stats;
 pub mod subcommand_inspect;
 pub mod subcommand_legacy;
+pub mod subcommand_list_codecs;
 pub mod types;
 pub mod video;
 pub mod video_h264;

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,8 @@ const VERBOSE_FLAG: noargs::FlagSpec =
 
 const INSPECT_COMMAND: noargs::CmdSpec =
     noargs::cmd("inspect").doc("録画ファイルの情報を取得します");
+const LIST_CODECS_COMMAND: noargs::CmdSpec =
+    noargs::cmd("list-codecs").doc("利用可能なコーデック一覧を表示します");
 const LEGACY_COMMAND: noargs::CmdSpec =
     noargs::cmd("legacy").doc("レガシー Hisui との互換性維持用のコマンドです（省略可能）");
 
@@ -33,6 +35,8 @@ fn main() -> noargs::Result<()> {
     // サブコマンドで分岐する
     if INSPECT_COMMAND.take(&mut args).is_present() {
         hisui::subcommand_inspect::run(args)?;
+    } else if LIST_CODECS_COMMAND.take(&mut args).is_present() {
+        hisui::subcommand_list_codecs::run(args)?;
     } else if LEGACY_COMMAND.take(&mut args).is_present() {
         hisui::subcommand_legacy::run(args)?;
     } else if args.metadata().help_mode {

--- a/src/subcommand_list_codecs.rs
+++ b/src/subcommand_list_codecs.rs
@@ -1,0 +1,112 @@
+use orfail::OrFail;
+
+pub fn run(args: noargs::RawArgs) -> noargs::Result<()> {
+    // 引数の解析を完了する（このサブコマンドは追加の引数を取らない）
+    if let Some(help) = args.finish()? {
+        print!("{help}");
+        return Ok(());
+    }
+
+    // 利用可能なコーデック情報を収集
+    let mut codecs = Vec::new();
+
+    // 音声コーデック
+    codecs.push(CodecInfo {
+        name: "Opus".to_string(),
+        codec_type: "audio".to_string(),
+        available: true,
+        description: "Opus audio codec".to_string(),
+    });
+
+    #[cfg(any(target_os = "macos", feature = "fdk-aac"))]
+    codecs.push(CodecInfo {
+        name: "AAC".to_string(),
+        codec_type: "audio".to_string(),
+        available: true,
+        description: "AAC audio codec".to_string(),
+    });
+
+    #[cfg(not(any(target_os = "macos", feature = "fdk-aac")))]
+    codecs.push(CodecInfo {
+        name: "AAC".to_string(),
+        codec_type: "audio".to_string(),
+        available: false,
+        description: "AAC audio codec (requires macOS or FDK-AAC feature)".to_string(),
+    });
+
+    // 映像コーデック
+    codecs.push(CodecInfo {
+        name: "VP8".to_string(),
+        codec_type: "video".to_string(),
+        available: true,
+        description: "VP8 video codec".to_string(),
+    });
+
+    codecs.push(CodecInfo {
+        name: "VP9".to_string(),
+        codec_type: "video".to_string(),
+        available: true,
+        description: "VP9 video codec".to_string(),
+    });
+
+    codecs.push(CodecInfo {
+        name: "H264".to_string(),
+        codec_type: "video".to_string(),
+        available: true,
+        description: "H.264 video codec".to_string(),
+    });
+
+    #[cfg(target_os = "macos")]
+    codecs.push(CodecInfo {
+        name: "H265".to_string(),
+        codec_type: "video".to_string(),
+        available: true,
+        description: "H.265 video codec (macOS only)".to_string(),
+    });
+
+    #[cfg(not(target_os = "macos"))]
+    codecs.push(CodecInfo {
+        name: "H265".to_string(),
+        codec_type: "video".to_string(),
+        available: false,
+        description: "H.265 video codec (macOS only)".to_string(),
+    });
+
+    codecs.push(CodecInfo {
+        name: "AV1".to_string(),
+        codec_type: "video".to_string(),
+        available: true,
+        description: "AV1 video codec".to_string(),
+    });
+
+    // JSON形式で出力
+    println!(
+        "{}",
+        nojson::json(|f| {
+            f.set_indent_size(2);
+            f.set_spacing(true);
+            f.object(|f| f.member("codecs", &codecs))
+        })
+    );
+
+    Ok(())
+}
+
+#[derive(Debug)]
+struct CodecInfo {
+    name: String,
+    codec_type: String,
+    available: bool,
+    description: String,
+}
+
+impl nojson::DisplayJson for CodecInfo {
+    fn fmt(&self, f: &mut nojson::JsonFormatter<'_, '_>) -> std::fmt::Result {
+        f.object(|f| {
+            f.member("name", &self.name)?;
+            f.member("type", &self.codec_type)?;
+            f.member("available", self.available)?;
+            f.member("description", &self.description)
+        })
+    }
+}

--- a/src/subcommand_list_codecs.rs
+++ b/src/subcommand_list_codecs.rs
@@ -1,7 +1,35 @@
 use orfail::OrFail;
 
+// fn show_codec_engines(&self) -> orfail::Result<()> {
+//     let openh264_lib = if let Some(path) = &self.args.openh264 {
+//         Some(Openh264Library::load(path).or_fail()?)
+//     } else {
+//         None
+//     };
+//     let options = VideoDecoderOptions {
+//         openh264_lib: openh264_lib.clone(),
+//     };
+
+//     let mut codec_engines = CodecEngines::default();
+
+//     AudioDecoder::update_codec_engines(&mut codec_engines);
+//     VideoDecoder::update_codec_engines(&mut codec_engines, options.clone());
+//     AudioEncoder::update_codec_engines(&mut codec_engines);
+//     VideoEncoder::update_codec_engines(&mut codec_engines, options);
+
+//     println!(
+//         "{}",
+//         nojson::json(|f| {
+//             f.set_indent_size(2);
+//             f.set_spacing(true);
+//             f.value(&codec_engines)
+//         })
+//     );
+
+//     Ok(())
+// }
+
 pub fn run(args: noargs::RawArgs) -> noargs::Result<()> {
-    // 引数の解析を完了する（このサブコマンドは追加の引数を取らない）
     if let Some(help) = args.finish()? {
         print!("{help}");
         return Ok(());

--- a/src/subcommand_list_codecs.rs
+++ b/src/subcommand_list_codecs.rs
@@ -1,33 +1,10 @@
 use orfail::OrFail;
+use std::collections::BTreeSet;
 
-// fn show_codec_engines(&self) -> orfail::Result<()> {
-//     let openh264_lib = if let Some(path) = &self.args.openh264 {
-//         Some(Openh264Library::load(path).or_fail()?)
-//     } else {
-//         None
-//     };
-//     let options = VideoDecoderOptions {
-//         openh264_lib: openh264_lib.clone(),
-//     };
-
-//     let mut codec_engines = CodecEngines::default();
-
-//     AudioDecoder::update_codec_engines(&mut codec_engines);
-//     VideoDecoder::update_codec_engines(&mut codec_engines, options.clone());
-//     AudioEncoder::update_codec_engines(&mut codec_engines);
-//     VideoEncoder::update_codec_engines(&mut codec_engines, options);
-
-//     println!(
-//         "{}",
-//         nojson::json(|f| {
-//             f.set_indent_size(2);
-//             f.set_spacing(true);
-//             f.value(&codec_engines)
-//         })
-//     );
-
-//     Ok(())
-// }
+// Import the necessary types from the codebase
+use crate::decoder::VideoDecoderOptions;
+use crate::encoder::{AudioEncoder, VideoEncoder};
+use crate::types::{CodecEngines, CodecName, EngineName};
 
 pub fn run(args: noargs::RawArgs) -> noargs::Result<()> {
     if let Some(help) = args.finish()? {
@@ -35,76 +12,76 @@ pub fn run(args: noargs::RawArgs) -> noargs::Result<()> {
         return Ok(());
     }
 
+    // Get codec engines information
+    let mut codec_engines = CodecEngines::default();
+
+    // Update codec engines with available encoders and decoders
+    AudioEncoder::update_codec_engines(&mut codec_engines);
+    VideoEncoder::update_codec_engines(&mut codec_engines, VideoDecoderOptions::default());
+    // Add decoder updates if available in your codebase
+
     // 利用可能なコーデック情報を収集
     let mut codecs = Vec::new();
 
     // 音声コーデック
     codecs.push(CodecInfo {
-        name: "Opus".to_string(),
-        codec_type: "audio".to_string(),
-        available: true,
-        description: "Opus audio codec".to_string(),
+        name: CodecName::Opus,
+        encoders: get_engines_for_codec(&codec_engines, CodecName::Opus, true),
+        decoders: get_engines_for_codec(&codec_engines, CodecName::Opus, false),
     });
 
     #[cfg(any(target_os = "macos", feature = "fdk-aac"))]
     codecs.push(CodecInfo {
-        name: "AAC".to_string(),
-        codec_type: "audio".to_string(),
-        available: true,
-        description: "AAC audio codec".to_string(),
+        name: CodecName::Aac,
+        encoders: get_engines_for_codec(&codec_engines, CodecName::Aac, true),
+        decoders: get_engines_for_codec(&codec_engines, CodecName::Aac, false),
     });
 
     #[cfg(not(any(target_os = "macos", feature = "fdk-aac")))]
     codecs.push(CodecInfo {
-        name: "AAC".to_string(),
+        name: CodecName::Aac,
         codec_type: "audio".to_string(),
-        available: false,
-        description: "AAC audio codec (requires macOS or FDK-AAC feature)".to_string(),
+        encoders: BTreeSet::new(),
+        decoders: BTreeSet::new(),
     });
 
     // 映像コーデック
     codecs.push(CodecInfo {
-        name: "VP8".to_string(),
-        codec_type: "video".to_string(),
-        available: true,
-        description: "VP8 video codec".to_string(),
+        name: CodecName::Vp8,
+        encoders: get_engines_for_codec(&codec_engines, CodecName::Vp8, true),
+        decoders: get_engines_for_codec(&codec_engines, CodecName::Vp8, false),
     });
 
     codecs.push(CodecInfo {
-        name: "VP9".to_string(),
-        codec_type: "video".to_string(),
-        available: true,
-        description: "VP9 video codec".to_string(),
+        name: CodecName::Vp9,
+        encoders: get_engines_for_codec(&codec_engines, CodecName::Vp9, true),
+        decoders: get_engines_for_codec(&codec_engines, CodecName::Vp9, false),
     });
 
     codecs.push(CodecInfo {
-        name: "H264".to_string(),
-        codec_type: "video".to_string(),
-        available: true,
-        description: "H.264 video codec".to_string(),
+        name: CodecName::H264,
+        encoders: get_engines_for_codec(&codec_engines, CodecName::H264, true),
+        decoders: get_engines_for_codec(&codec_engines, CodecName::H264, false),
     });
 
     #[cfg(target_os = "macos")]
     codecs.push(CodecInfo {
-        name: "H265".to_string(),
-        codec_type: "video".to_string(),
-        available: true,
-        description: "H.265 video codec (macOS only)".to_string(),
+        name: CodecName::H265,
+        encoders: get_engines_for_codec(&codec_engines, CodecName::H265, true),
+        decoders: get_engines_for_codec(&codec_engines, CodecName::H265, false),
     });
 
     #[cfg(not(target_os = "macos"))]
     codecs.push(CodecInfo {
-        name: "H265".to_string(),
-        codec_type: "video".to_string(),
-        available: false,
-        description: "H.265 video codec (macOS only)".to_string(),
+        name: CodecName::H265,
+        encoders: BTreeSet::new(),
+        decoders: BTreeSet::new(),
     });
 
     codecs.push(CodecInfo {
-        name: "AV1".to_string(),
-        codec_type: "video".to_string(),
-        available: true,
-        description: "AV1 video codec".to_string(),
+        name: CodecName::Av1,
+        encoders: get_engines_for_codec(&codec_engines, CodecName::Av1, true),
+        decoders: get_engines_for_codec(&codec_engines, CodecName::Av1, false),
     });
 
     // JSON形式で出力
@@ -113,7 +90,7 @@ pub fn run(args: noargs::RawArgs) -> noargs::Result<()> {
         nojson::json(|f| {
             f.set_indent_size(2);
             f.set_spacing(true);
-            f.object(|f| f.member("codecs", &codecs))
+            f.value(&codecs)
         })
     );
 
@@ -122,19 +99,37 @@ pub fn run(args: noargs::RawArgs) -> noargs::Result<()> {
 
 #[derive(Debug)]
 struct CodecInfo {
-    name: String,
-    codec_type: String,
-    available: bool,
-    description: String,
+    name: CodecName,
+    encoders: BTreeSet<EngineName>,
+    decoders: BTreeSet<EngineName>,
 }
 
 impl nojson::DisplayJson for CodecInfo {
     fn fmt(&self, f: &mut nojson::JsonFormatter<'_, '_>) -> std::fmt::Result {
         f.object(|f| {
-            f.member("name", &self.name)?;
-            f.member("type", &self.codec_type)?;
-            f.member("available", self.available)?;
-            f.member("description", &self.description)
+            f.member("name", self.name)?;
+            f.member(
+                "type",
+                if matches!(self.name, CodecName::Opus | CodecName::Aac) {
+                    "audio"
+                } else {
+                    "video"
+                },
+            )?;
+            f.member("encoders", &self.encoders)?;
+            f.member("decoders", &self.decoders)
         })
     }
+}
+
+// Helper function to extract engines for a specific codec
+fn get_engines_for_codec(
+    codec_engines: &CodecEngines,
+    codec: CodecName,
+    is_encoder: bool,
+) -> BTreeSet<EngineName> {
+    // This function would need to be implemented based on how CodecEngines works
+    // You'll need to check the CodecEngines implementation to see how to query it
+    // This is a placeholder - you'll need to adapt based on the actual API
+    BTreeSet::new()
 }

--- a/src/subcommand_list_codecs.rs
+++ b/src/subcommand_list_codecs.rs
@@ -69,19 +69,19 @@ impl nojson::DisplayJson for CodecInfo {
                 },
             )?;
             f.member(
-                "encoders",
+                "decoders",
                 nojson::json(|f| {
                     f.set_indent_size(0);
-                    f.value(&self.encoders)?;
+                    f.value(&self.decoders)?;
                     f.set_indent_size(2);
                     Ok(())
                 }),
             )?;
             f.member(
-                "decoders",
+                "encoders",
                 nojson::json(|f| {
                     f.set_indent_size(0);
-                    f.value(&self.decoders)?;
+                    f.value(&self.encoders)?;
                     f.set_indent_size(2);
                     Ok(())
                 }),

--- a/src/subcommand_list_codecs.rs
+++ b/src/subcommand_list_codecs.rs
@@ -1,17 +1,26 @@
+use std::path::PathBuf;
+
+use shiguredo_openh264::Openh264Library;
+
 use crate::{
     decoder::{AudioDecoder, VideoDecoder},
     encoder::{AudioEncoder, VideoEncoder},
     types::{CodecName, EngineName},
 };
 
-pub fn run(args: noargs::RawArgs) -> noargs::Result<()> {
+pub fn run(mut args: noargs::RawArgs) -> noargs::Result<()> {
+    let openh264: Option<PathBuf> = noargs::opt("openh264")
+        .ty("PATH")
+        .env("HISUI_OPENH264_PATH")
+        .doc("OpenH264 の共有ライブラリのパス")
+        .take(&mut args)
+        .present_and_then(|a| a.value().parse())?;
     if let Some(help) = args.finish()? {
         print!("{help}");
         return Ok(());
     }
 
-    // TODO:
-    let is_openh264_available = false;
+    let is_openh264_available = openh264.is_some_and(|path| Openh264Library::load(path).is_ok());
 
     let mut codecs = Vec::new();
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,8 +1,5 @@
 //! 雑多な型定義をまとめたモジュール
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    str::FromStr,
-};
+use std::str::FromStr;
 
 /// コーデック名
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -182,51 +179,5 @@ impl std::ops::Mul<usize> for EvenUsize {
 
     fn mul(self, rhs: usize) -> Self::Output {
         Self(self.0 * rhs)
-    }
-}
-
-#[derive(Debug, Default)]
-pub struct CodecEngines(BTreeMap<CodecName, Engines>);
-
-impl CodecEngines {
-    pub fn insert_decoder(&mut self, codec: CodecName, engine: EngineName) {
-        self.0.entry(codec).or_default().decoders.insert(engine);
-    }
-
-    pub fn insert_encoder(&mut self, codec: CodecName, engine: EngineName) {
-        self.0.entry(codec).or_default().encoders.insert(engine);
-    }
-}
-
-impl nojson::DisplayJson for CodecEngines {
-    fn fmt(&self, f: &mut nojson::JsonFormatter<'_, '_>) -> std::fmt::Result {
-        f.object(|f| {
-            f.members(
-                self.0
-                    .iter()
-                    .map(|(name, engines)| (name.as_str(), engines)),
-            )
-        })
-    }
-}
-
-#[derive(Debug, Default)]
-pub struct Engines {
-    pub encoders: BTreeSet<EngineName>,
-    pub decoders: BTreeSet<EngineName>,
-}
-
-impl nojson::DisplayJson for Engines {
-    fn fmt(&self, f: &mut nojson::JsonFormatter<'_, '_>) -> std::fmt::Result {
-        f.object(|f| {
-            f.member(
-                "encoders",
-                nojson::json(|f| f.array(|f| f.elements(self.encoders.iter().map(|x| x.as_str())))),
-            )?;
-            f.member(
-                "decoders",
-                nojson::json(|f| f.array(|f| f.elements(self.decoders.iter().map(|x| x.as_str())))),
-            )
-        })
     }
 }


### PR DESCRIPTION
This pull request refactors the codec engine management system by removing the `CodecEngines` structure and its associated logic, simplifying the codebase, and introducing a new `list-codecs` command for displaying available codecs. The changes primarily focus on restructuring how codecs and their engines are retrieved and displayed, improving maintainability and reducing complexity.

### Removal of `CodecEngines` and Associated Code

* [`src/types.rs`](diffhunk://#diff-ed12f5ea605f23bb4d26cc65778e3daff9db3eec40e2abfc82beafca130a99a0L2-R2): Removed the `CodecEngines` and `Engines` structures, along with their methods for managing codec and engine mappings. This eliminates the centralized codec engine registry in favor of direct retrieval methods. [[1]](diffhunk://#diff-ed12f5ea605f23bb4d26cc65778e3daff9db3eec40e2abfc82beafca130a99a0L2-R2) [[2]](diffhunk://#diff-ed12f5ea605f23bb4d26cc65778e3daff9db3eec40e2abfc82beafca130a99a0L187-L232)
* `src/decoder.rs` and `src/encoder.rs`: Replaced `update_codec_engines` methods with `get_engines` methods, which directly return available engines for a given codec. This simplifies codec engine retrieval logic. [[1]](diffhunk://#diff-a71a0bb50f59b4a15fa7e159f9c5d10e22410f725aa7f48e390524c9fec919cbL33-R38) [[2]](diffhunk://#diff-a71a0bb50f59b4a15fa7e159f9c5d10e22410f725aa7f48e390524c9fec919cbL61-R91) [[3]](diffhunk://#diff-9a5ef4cd6ac7a66abd842b474ee88447516ed3bd218748eb6f387a0895d14fcbL36-L45) [[4]](diffhunk://#diff-9a5ef4cd6ac7a66abd842b474ee88447516ed3bd218748eb6f387a0895d14fcbR90-R108) [[5]](diffhunk://#diff-9a5ef4cd6ac7a66abd842b474ee88447516ed3bd218748eb6f387a0895d14fcbL113-L128) [[6]](diffhunk://#diff-9a5ef4cd6ac7a66abd842b474ee88447516ed3bd218748eb6f387a0895d14fcbR212-R240)

### Introduction of `list-codecs` Command

* [`src/lib.rs`](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R35): Added the `subcommand_list_codecs` module.
* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR11-R12): Introduced the `list-codecs` command to display available codecs and their engines. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR11-R12) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR38-R39)
* [`src/subcommand_list_codecs.rs`](diffhunk://#diff-6f181bbc24822e3a1923fe6beda11b685d89d88bffed017475a1687035a2186dR1-R101): Implemented the logic for the `list-codecs` command, which retrieves codec information using the new `get_engines` methods and outputs it in JSON format.

### Removal of Obsolete `codec-engines` Flag

* [`src/command_line_args.rs`](diffhunk://#diff-4c9702dae802d6267efb86b5af5b536f88dd04b36b21cc52812436e4aa67fb2cL22-L33): Removed the `codec_engines` flag and its associated logic. Updated warning messages to direct users to the new `list-codecs` command. [[1]](diffhunk://#diff-4c9702dae802d6267efb86b5af5b536f88dd04b36b21cc52812436e4aa67fb2cL22-L33) [[2]](diffhunk://#diff-4c9702dae802d6267efb86b5af5b536f88dd04b36b21cc52812436e4aa67fb2cL201-R196) [[3]](diffhunk://#diff-4c9702dae802d6267efb86b5af5b536f88dd04b36b21cc52812436e4aa67fb2cL237-L243)
* [`src/runner.rs`](diffhunk://#diff-68c6f449503a33c74a15800c0a9c8fd34028465a06edcac92b32bbb9db64bbceL35-L40): Removed the `show_codec_engines` method and the handling of the `codec_engines` flag. [[1]](diffhunk://#diff-68c6f449503a33c74a15800c0a9c8fd34028465a06edcac92b32bbb9db64bbceL35-L40) [[2]](diffhunk://#diff-68c6f449503a33c74a15800c0a9c8fd34028465a06edcac92b32bbb9db64bbceL133-L161)

### Code Cleanup and Adjustments

* `src/decoder.rs`, `src/encoder.rs`, and `src/runner.rs`: Adjusted imports to remove references to `CodecEngines`. [[1]](diffhunk://#diff-a71a0bb50f59b4a15fa7e159f9c5d10e22410f725aa7f48e390524c9fec919cbL13-R13) [[2]](diffhunk://#diff-9a5ef4cd6ac7a66abd842b474ee88447516ed3bd218748eb6f387a0895d14fcbL15-R21) [[3]](diffhunk://#diff-68c6f449503a33c74a15800c0a9c8fd34028465a06edcac92b32bbb9db64bbceL11-R19)

These changes streamline codec management, introduce a user-friendly command for codec inspection, and remove outdated functionality, improving both the user experience and code maintainability.