### PR TITLE
`resolution` をオプショナルにする＆リージョンに `cell_width` と `cell_height` を追加する

### DIFF
--- a/src/layout.rs
+++ b/src/layout.rs
@@ -168,7 +168,7 @@ struct RawLayout {
     audio_sources_excluded: Vec<PathBuf>,
     video_layout: BTreeMap<String, RawRegion>,
     trim: bool,
-    resolution: Option<Resolution>,
+    resolution: Option<Resolution>, // TODO: ユニットテスト追加 (None の場合)
     bitrate: usize,
 }
 
@@ -319,8 +319,8 @@ struct RawRegion {
     video_sources: Vec<PathBuf>,
     video_sources_excluded: Vec<PathBuf>,
     width: usize,
-    cell_width: usize,
-    cell_height: usize,
+    cell_width: usize,  // TODO: ユニットテスト追加
+    cell_height: usize, // TODO: ユニットテスト追加
     x_pos: usize,
     y_pos: usize,
     z_pos: isize,

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -433,6 +433,34 @@ impl RawRegion {
             &self.cells_excluded,
         );
 
+        if self.cell_width != 0 {
+            let horizontal_inner_borders = BORDER_PIXELS.get() * (columns - 1);
+            let grid_width = self.cell_width * columns + horizontal_inner_borders;
+
+            // 外枠を考慮
+            self.width = if resolution
+                .is_some_and(|r| grid_width + BORDER_PIXELS.get() * 2 <= r.width.get())
+            {
+                grid_width + BORDER_PIXELS.get() * 2
+            } else {
+                grid_width
+            };
+        }
+
+        if self.cell_height != 0 {
+            let vertical_inner_borders = BORDER_PIXELS.get() * (rows - 1);
+            let grid_height = self.cell_height * rows + vertical_inner_borders;
+
+            // 外枠を考慮
+            self.height = if resolution
+                .is_some_and(|r| grid_height + BORDER_PIXELS.get() * 2 <= r.height.get())
+            {
+                grid_height + BORDER_PIXELS.get() * 2
+            } else {
+                grid_height
+            };
+        }
+
         // 解像度を確定する
         let resolution = if let Some(resolution) = resolution {
             resolution
@@ -451,32 +479,7 @@ impl RawRegion {
             Resolution::new(required_width, required_height).or_fail()?
         };
 
-        if self.cell_width != 0 {
-            let horizontal_inner_borders = BORDER_PIXELS.get() * (columns - 1);
-            let grid_width = self.cell_width * columns + horizontal_inner_borders;
-
-            // 外枠を考慮
-            self.width = if grid_width + BORDER_PIXELS.get() * 2 <= resolution.width.get() {
-                grid_width + BORDER_PIXELS.get() * 2
-            } else {
-                grid_width
-            };
-        }
-
-        if self.cell_height != 0 {
-            let vertical_inner_borders = BORDER_PIXELS.get() * (rows - 1);
-            let grid_height = self.cell_height * rows + vertical_inner_borders;
-
-            // 外枠を考慮
-            self.height = if grid_height + BORDER_PIXELS.get() * 2 <= resolution.height.get() {
-                grid_height + BORDER_PIXELS.get() * 2
-            } else {
-                grid_height
-            };
-        }
-
-        // Validate and adjust dimensions directly on self
-        // Check and adjust height
+        // 高さの確認と調整
         if self.height != 0 {
             (16..=resolution.height.get())
                 .contains(&self.height)
@@ -486,40 +489,40 @@ impl RawRegion {
                         self.height
                     )
                 })?;
-            self.height -= self.height % 2; // Make even
+            self.height -= self.height % 2; // 偶数にする
         } else {
-            // 0 means auto-calculate
+            // 0 は自動計算を意味する
             self.height = resolution.height.get().saturating_sub(self.y_pos);
         }
 
-        // Check and adjust width
+        // 幅の確認と調整
         if self.width != 0 {
             (16..=resolution.width.get())
                 .contains(&self.width)
                 .or_fail_with(|()| {
                     format!("video_layout region width is out of range: {}", self.width)
                 })?;
-            self.width -= self.width % 2; // Make even
+            self.width -= self.width % 2; // 偶数にする
         } else {
-            // 0 means auto-calculate
+            // 0 は自動計算を意味する
             self.width = resolution.width.get().saturating_sub(self.x_pos);
         }
 
-        // Check y_pos
+        // y_pos の確認
         (0..resolution.height.get())
             .contains(&self.y_pos)
             .or_fail_with(|()| {
                 format!("video_layout region y_pos is out of range: {}", self.y_pos)
             })?;
 
-        // Check x_pos
+        // x_pos の確認
         (0..resolution.width.get())
             .contains(&self.x_pos)
             .or_fail_with(|()| {
                 format!("video_layout region x_pos is out of range: {}", self.x_pos)
             })?;
 
-        // Check z_pos
+        // z_pos の確認
         (-99..=99).contains(&self.z_pos).or_fail_with(|()| {
             format!("video_layout region z_pos is out of range: {}", self.z_pos)
         })?;

--- a/src/subcommand_compose.rs
+++ b/src/subcommand_compose.rs
@@ -10,10 +10,12 @@ use crate::{composer::Composer, layout::Layout, types::CodecName, video::FrameRa
 
 // TODO: resolution は必須ではなくして、省略時には動的に求められるようにする
 const DEFAULT_LAYOUT_JSON: &str = r#"{
-  "resolution": "1280x720",
   "audio_sources": [ "archive*.json" ],
   "video_layout": {"main": {
-    "max_columns": 3,
+    "cell_width": 320,
+    "cell_height": 240,
+    "max_columns": 4,
+    "max_rows": 4,
     "video_sources": [ "archive*.json" ]
   }}
 }"#;
@@ -31,7 +33,10 @@ pub fn run(mut args: noargs::RawArgs) -> noargs::Result<()> {
             r#"{"#,
             r#"  "audio_sources": [ "archive*.json" ],"#,
             r#"  "video_layout": {"main": {"#,
-            r#"    "max_columns": 3,"#,
+            r#"    "cell_width": 320,"#,
+            r#"    "cell_height": 240,"#,
+            r#"    "max_columns": 4,"#,
+            r#"    "max_rows": 4,"#,
             r#"    "video_sources": [ "archive*.json" ]"#,
             r#"  }}"#,
             r#"}"#

--- a/src/subcommand_compose.rs
+++ b/src/subcommand_compose.rs
@@ -8,7 +8,6 @@ use shiguredo_openh264::Openh264Library;
 
 use crate::{composer::Composer, layout::Layout, types::CodecName, video::FrameRate};
 
-// TODO: resolution は必須ではなくして、省略時には動的に求められるようにする
 const DEFAULT_LAYOUT_JSON: &str = r#"{
   "audio_sources": [ "archive*.json" ],
   "video_layout": {"main": {


### PR DESCRIPTION
This pull request introduces significant changes to the `src/layout.rs` file to enhance flexibility in handling video layout resolutions and regions, as well as updates to the default layout configuration in `src/subcommand_compose.rs`. Key improvements include making resolution optional, adding new properties for grid-based layouts, and dynamically calculating resolution when unspecified.

### Enhancements to resolution handling:

* [`src/layout.rs`](diffhunk://#diff-7937a85ae16def66de428ea5dc339277fc8ca7bb7e40c247dc0b485acc39da6cL171-R188): Changed the `resolution` field in `RawLayout` to `Option<Resolution>`, allowing dynamic resolution calculation when not explicitly specified. Added logic to infer resolution from video regions if omitted. [[1]](diffhunk://#diff-7937a85ae16def66de428ea5dc339277fc8ca7bb7e40c247dc0b485acc39da6cL171-R188) [[2]](diffhunk://#diff-7937a85ae16def66de428ea5dc339277fc8ca7bb7e40c247dc0b485acc39da6cL285-R250) [[3]](diffhunk://#diff-7937a85ae16def66de428ea5dc339277fc8ca7bb7e40c247dc0b485acc39da6cL300-R260)

### Grid-based layout improvements:

* [`src/layout.rs`](diffhunk://#diff-7937a85ae16def66de428ea5dc339277fc8ca7bb7e40c247dc0b485acc39da6cR322-R323): Introduced `cell_width` and `cell_height` fields in `RawRegion` for grid-based layouts. Added validation to prevent simultaneous specification of both `width` and `cell_width` (or `height` and `cell_height`) for a region. Implemented logic to calculate region dimensions based on grid properties. [[1]](diffhunk://#diff-7937a85ae16def66de428ea5dc339277fc8ca7bb7e40c247dc0b485acc39da6cR322-R323) [[2]](diffhunk://#diff-7937a85ae16def66de428ea5dc339277fc8ca7bb7e40c247dc0b485acc39da6cL419-R407) [[3]](diffhunk://#diff-7937a85ae16def66de428ea5dc339277fc8ca7bb7e40c247dc0b485acc39da6cR436-R533)

### Updates to default layout configuration:

* [`src/subcommand_compose.rs`](diffhunk://#diff-3039200c5856c186d5c8304513cfe625cf169ce0e0656146a1da5eec20757347L11-R17): Updated `DEFAULT_LAYOUT_JSON` to use `cell_width` and `cell_height` for grid-based layouts, replacing fixed dimensions with dynamic grid properties. Increased `max_columns` and added `max_rows` for enhanced layout flexibility. [[1]](diffhunk://#diff-3039200c5856c186d5c8304513cfe625cf169ce0e0656146a1da5eec20757347L11-R17) [[2]](diffhunk://#diff-3039200c5856c186d5c8304513cfe625cf169ce0e0656146a1da5eec20757347L34-R38)