### PR TITLE
libvpx のエンコードパラメータを JSON で指定可能にする

### DIFF
--- a/src/composer.rs
+++ b/src/composer.rs
@@ -23,8 +23,6 @@ use crate::{
 #[derive(Debug)]
 pub struct Composer {
     pub layout: Layout,
-    pub video_codec: CodecName,
-    pub audio_codec: CodecName,
     pub openh264_lib: Option<Openh264Library>,
     pub show_progress_bar: bool,
     pub max_cpu_cores: Option<usize>,
@@ -45,8 +43,6 @@ impl Composer {
     pub fn new(layout: Layout) -> Self {
         Self {
             layout,
-            video_codec: CodecName::Vp8,
-            audio_codec: CodecName::Opus,
             openh264_lib: None,
             show_progress_bar: false,
             max_cpu_cores: None,
@@ -153,7 +149,7 @@ impl Composer {
             stats.clone(),
         );
 
-        let encoder = match self.video_codec {
+        let encoder = match self.layout.video_codec {
             CodecName::Vp8 => VideoEncoder::new_vp8(&self.layout).or_fail()?,
             CodecName::Vp9 => VideoEncoder::new_vp9(&self.layout).or_fail()?,
             #[cfg(target_os = "macos")]
@@ -197,7 +193,7 @@ impl Composer {
             stats.clone(),
         );
 
-        let audio_encoder = match self.audio_codec {
+        let audio_encoder = match self.layout.audio_codec {
             #[cfg(feature = "fdk-aac")]
             CodecName::Aac => AudioEncoder::new_fdk_aac(self.out_aac_bit_rate).or_fail()?,
             #[cfg(all(not(feature = "fdk-aac"), target_os = "macos"))]

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -118,23 +118,13 @@ pub enum VideoEncoder {
 }
 
 impl VideoEncoder {
-    pub fn new_vp8(
-        layout: &Layout,
-        cq_level: usize,
-        min_q: usize,
-        max_q: usize,
-    ) -> orfail::Result<Self> {
-        let encoder = LibvpxEncoder::new_vp8(layout, cq_level, min_q, max_q).or_fail()?;
+    pub fn new_vp8(layout: &Layout) -> orfail::Result<Self> {
+        let encoder = LibvpxEncoder::new_vp8(layout).or_fail()?;
         Ok(Self::Libvpx(encoder))
     }
 
-    pub fn new_vp9(
-        layout: &Layout,
-        cq_level: usize,
-        min_q: usize,
-        max_q: usize,
-    ) -> orfail::Result<Self> {
-        let encoder = LibvpxEncoder::new_vp9(layout, cq_level, min_q, max_q).or_fail()?;
+    pub fn new_vp9(layout: &Layout) -> orfail::Result<Self> {
+        let encoder = LibvpxEncoder::new_vp9(layout).or_fail()?;
         Ok(Self::Libvpx(encoder))
     }
 

--- a/src/encoder_libvpx.rs
+++ b/src/encoder_libvpx.rs
@@ -45,10 +45,10 @@ impl LibvpxEncoder {
             fps_numerator: layout.fps.numerator.get(),
             fps_denominator: layout.fps.denumerator.get(),
             target_bitrate: layout.video_bitrate_bps(),
-            min_quantizer: min_q,
-            max_quantizer: max_q,
+            min_quantizer: min_q, // TODO: layout の値を使うようにする
+            max_quantizer: max_q, // TODO: layout の値を使うようにする
             cq_level,
-            ..Default::default()
+            ..layout.encode_params.libvpx_vp8.clone().unwrap_or_default()
         };
         let inner = shiguredo_libvpx::Encoder::new_vp8(&config).or_fail()?;
 
@@ -77,10 +77,10 @@ impl LibvpxEncoder {
             fps_numerator: layout.fps.numerator.get(),
             fps_denominator: layout.fps.denumerator.get(),
             target_bitrate: layout.video_bitrate_bps(),
-            min_quantizer: min_q,
-            max_quantizer: max_q,
+            min_quantizer: min_q, // TODO: layout の値を使うようにする
+            max_quantizer: max_q, // TODO: layout の値を使うようにする
             cq_level,
-            ..Default::default()
+            ..layout.encode_params.libvpx_vp9.clone().unwrap_or_default()
         };
         let inner = shiguredo_libvpx::Encoder::new_vp9(&config).or_fail()?;
 

--- a/src/encoder_libvpx.rs
+++ b/src/encoder_libvpx.rs
@@ -50,6 +50,7 @@ impl LibvpxEncoder {
             cq_level,
             ..layout.encode_params.libvpx_vp8.clone().unwrap_or_default()
         };
+        log::debug!("libvpx vp8 encoder config: {config:?}");
         let inner = shiguredo_libvpx::Encoder::new_vp8(&config).or_fail()?;
 
         let width = layout.resolution.width();
@@ -82,6 +83,7 @@ impl LibvpxEncoder {
             cq_level,
             ..layout.encode_params.libvpx_vp9.clone().unwrap_or_default()
         };
+        log::debug!("libvpx vp9 encoder config: {config:?}");
         let inner = shiguredo_libvpx::Encoder::new_vp9(&config).or_fail()?;
 
         let width = layout.resolution.width();

--- a/src/encoder_libvpx.rs
+++ b/src/encoder_libvpx.rs
@@ -33,21 +33,13 @@ pub struct LibvpxEncoder {
 }
 
 impl LibvpxEncoder {
-    pub fn new_vp8(
-        layout: &Layout,
-        cq_level: usize,
-        min_q: usize,
-        max_q: usize,
-    ) -> orfail::Result<Self> {
+    pub fn new_vp8(layout: &Layout) -> orfail::Result<Self> {
         let config = shiguredo_libvpx::EncoderConfig {
             width: layout.resolution.width().get(),
             height: layout.resolution.height().get(),
             fps_numerator: layout.fps.numerator.get(),
             fps_denominator: layout.fps.denumerator.get(),
             target_bitrate: layout.video_bitrate_bps(),
-            min_quantizer: min_q, // TODO: layout の値を使うようにする
-            max_quantizer: max_q, // TODO: layout の値を使うようにする
-            cq_level,
             ..layout.encode_params.libvpx_vp8.clone().unwrap_or_default()
         };
         log::debug!("libvpx vp8 encoder config: {config:?}");
@@ -66,21 +58,13 @@ impl LibvpxEncoder {
         })
     }
 
-    pub fn new_vp9(
-        layout: &Layout,
-        cq_level: usize,
-        min_q: usize,
-        max_q: usize,
-    ) -> orfail::Result<Self> {
+    pub fn new_vp9(layout: &Layout) -> orfail::Result<Self> {
         let config = shiguredo_libvpx::EncoderConfig {
             width: layout.resolution.width().get(),
             height: layout.resolution.height().get(),
             fps_numerator: layout.fps.numerator.get(),
             fps_denominator: layout.fps.denumerator.get(),
             target_bitrate: layout.video_bitrate_bps(),
-            min_quantizer: min_q, // TODO: layout の値を使うようにする
-            max_quantizer: max_q, // TODO: layout の値を使うようにする
-            cq_level,
             ..layout.encode_params.libvpx_vp9.clone().unwrap_or_default()
         };
         log::debug!("libvpx vp9 encoder config: {config:?}");

--- a/src/encoder_libvpx_params.rs
+++ b/src/encoder_libvpx_params.rs
@@ -29,103 +29,67 @@ pub fn parse_libvpx_vp8_encode_params(
             "best" => Ok(shiguredo_libvpx::EncodingDeadline::Best),
             "good" => Ok(shiguredo_libvpx::EncodingDeadline::Good),
             "realtime" => Ok(shiguredo_libvpx::EncodingDeadline::Realtime),
-            _ => Err(v.invalid("")),
+            _ => Err(v.invalid("unknown 'deadline' value")),
         })?
     {
         config.deadline = deadline;
     }
 
-    // // レート制御モード
-    // if let Some(rate_control) = params.get("rate_control") {
-    //     config.rate_control = match rate_control.to_str()? {
-    //         "vbr" => shiguredo_libvpx::RateControlMode::Vbr,
-    //         "cbr" => shiguredo_libvpx::RateControlMode::Cbr,
-    //         "cq" => shiguredo_libvpx::RateControlMode::Cq,
-    //         _ => return Err(nojson::JsonParseError::InvalidValue),
-    //     };
-    // }
+    // レート制御モード
+    if let Some(rate_control) = params.get_with("rate_control", |v| {
+        match v.to_unquoted_string_str()?.as_ref() {
+            "vbr" => Ok(shiguredo_libvpx::RateControlMode::Vbr),
+            "cbr" => Ok(shiguredo_libvpx::RateControlMode::Cbr),
+            "cq" => Ok(shiguredo_libvpx::RateControlMode::Cq),
+            _ => Err(v.invalid("unknown 'rate_control' value")),
+        }
+    })? {
+        config.rate_control = rate_control;
+    }
 
-    // // 先読みフレーム数
-    // if let Some(lag_in_frames) = params.get("lag_in_frames") {
-    //     if let Ok(lag) = std::num::NonZeroUsize::new(lag_in_frames.to_u64()? as usize) {
-    //         config.lag_in_frames = Some(lag);
-    //     }
-    // }
+    // 先読みフレーム数
+    config.lag_in_frames = params.get("lag_in_frames")?;
 
-    // // スレッド数
-    // if let Some(threads) = params.get("threads") {
-    //     if let Ok(thread_count) = std::num::NonZeroUsize::new(threads.to_u64()? as usize) {
-    //         config.threads = Some(thread_count);
-    //     }
-    // }
+    // スレッド数
+    if let Some(threads) = params.get("threads")? {
+        if let Some(thread_count) = std::num::NonZeroUsize::new(threads) {
+            config.threads = Some(thread_count);
+        }
+    }
 
-    // // エラー耐性モード
-    // if let Some(error_resilient) = params.get("error_resilient") {
-    //     config.error_resilient = error_resilient.to_bool()?;
-    // }
+    // エラー耐性モード
+    config.error_resilient = params.get("error_resilient")?.unwrap_or_default();
 
-    // // キーフレーム間隔
-    // if let Some(keyframe_interval) = params.get("keyframe_interval") {
-    //     if let Ok(interval) = std::num::NonZeroUsize::new(keyframe_interval.to_u64()? as usize) {
-    //         config.keyframe_interval = Some(interval);
-    //     }
-    // }
+    // キーフレーム間隔
+    config.keyframe_interval = params.get("keyframe_interval")?;
 
-    // // フレームドロップ閾値
-    // if let Some(frame_drop_threshold) = params.get("frame_drop_threshold") {
-    //     config.frame_drop_threshold = Some(frame_drop_threshold.to_u64()? as usize);
-    // }
+    // フレームドロップ閾値
+    config.frame_drop_threshold = params.get("frame_drop_threshold")?;
 
-    // // 以降はVP8固有の設定
-    // let mut vp8_config = shiguredo_libvpx::Vp8Config {
-    //     noise_sensitivity: None,
-    //     static_threshold: None,
-    //     token_partitions: None,
-    //     max_intra_bitrate_pct: None,
-    //     arnr_config: None,
-    // };
+    // 以降はVP8固有の設定
+    let mut vp8_config = shiguredo_libvpx::Vp8Config {
+        noise_sensitivity: None,
+        static_threshold: None,
+        token_partitions: None,
+        max_intra_bitrate_pct: None,
+        arnr_config: None,
+    };
+    vp8_config.noise_sensitivity = params.get("noise_sensitivity")?;
+    vp8_config.static_threshold = params.get("static_threshold")?;
+    vp8_config.token_partitions = params.get("token_partitions")?;
+    vp8_config.max_intra_bitrate_pct = params.get("max_intra_bitrate_pct")?;
 
-    // if let Some(noise_sensitivity) = params.get("noise_sensitivity") {
-    //     vp8_config.noise_sensitivity = Some(noise_sensitivity.to_i64()? as i32);
-    // }
+    // ARNR設定
+    vp8_config.arnr_config = params.get_with("arnr_config", |v| {
+        let arnr_obj = JsonObject::new(v)?;
+        Ok(shiguredo_libvpx::ArnrConfig {
+            max_frames: arnr_obj.get("max_frames")?.unwrap_or(0) as i32,
+            strength: arnr_obj.get("strength")?.unwrap_or(3) as i32,
+            filter_type: arnr_obj.get("filter_type")?.unwrap_or(1) as i32,
+        })
+    })?;
 
-    // if let Some(static_threshold) = params.get("static_threshold") {
-    //     vp8_config.static_threshold = Some(static_threshold.to_i64()? as i32);
-    // }
-
-    // if let Some(token_partitions) = params.get("token_partitions") {
-    //     vp8_config.token_partitions = Some(token_partitions.to_i64()? as i32);
-    // }
-
-    // if let Some(max_intra_bitrate_pct) = params.get("max_intra_bitrate_pct") {
-    //     vp8_config.max_intra_bitrate_pct = Some(max_intra_bitrate_pct.to_i64()? as i32);
-    // }
-
-    // // ARNR設定
-    // if let Some(arnr_params) = params.get("arnr_config") {
-    //     let arnr_obj = arnr_params.to_object()?;
-    //     let arnr_config = shiguredo_libvpx::ArnrConfig {
-    //         max_frames: arnr_obj
-    //             .get("max_frames")
-    //             .map(|v| v.to_i64())
-    //             .transpose()?
-    //             .unwrap_or(0) as i32,
-    //         strength: arnr_obj
-    //             .get("strength")
-    //             .map(|v| v.to_i64())
-    //             .transpose()?
-    //             .unwrap_or(3) as i32,
-    //         filter_type: arnr_obj
-    //             .get("filter_type")
-    //             .map(|v| v.to_i64())
-    //             .transpose()?
-    //             .unwrap_or(1) as i32,
-    //     };
-    //     vp8_config.arnr_config = Some(arnr_config);
-    // }
-
-    // config.vp8_config = Some(vp8_config);
-
+    config.vp8_config = Some(vp8_config);
     Ok(config)
 }
 

--- a/src/encoder_libvpx_params.rs
+++ b/src/encoder_libvpx_params.rs
@@ -1,0 +1,143 @@
+use crate::json::JsonObject;
+
+// エンコードパラメーターのデフォルト値
+const DEFAULT_CQ_LEVEL: usize = 30;
+const DEFAULT_MIN_Q: usize = 10;
+const DEFAULT_MAX_Q: usize = 50;
+
+pub fn parse_libvpx_vp8_encode_params(
+    value: nojson::RawJsonValue<'_, '_>,
+) -> Result<shiguredo_libvpx::EncoderConfig, nojson::JsonParseError> {
+    // [NOTE] 以下は後で別途設定するので、ここではパースしない:
+    // - width
+    // - height
+    // - fps_numerator
+    // - fps_denominator
+    // - target_bitrate
+    let params = JsonObject::new(value)?;
+    let mut config = shiguredo_libvpx::EncoderConfig::default();
+
+    // 基本的なエンコーダーパラメーター
+    config.min_quantizer = params.get("min_quantizer")?.unwrap_or(DEFAULT_MIN_Q);
+    config.max_quantizer = params.get("max_quantizer")?.unwrap_or(DEFAULT_MAX_Q);
+    config.cq_level = params.get("cq_level")?.unwrap_or(DEFAULT_CQ_LEVEL);
+    config.cpu_used = params.get("cpu_used")?;
+
+    // エンコード期限設定
+    if let Some(deadline) =
+        params.get_with("deadline", |v| match v.to_unquoted_string_str()?.as_ref() {
+            "best" => Ok(shiguredo_libvpx::EncodingDeadline::Best),
+            "good" => Ok(shiguredo_libvpx::EncodingDeadline::Good),
+            "realtime" => Ok(shiguredo_libvpx::EncodingDeadline::Realtime),
+            _ => Err(v.invalid("")),
+        })?
+    {
+        config.deadline = deadline;
+    }
+
+    // // レート制御モード
+    // if let Some(rate_control) = params.get("rate_control") {
+    //     config.rate_control = match rate_control.to_str()? {
+    //         "vbr" => shiguredo_libvpx::RateControlMode::Vbr,
+    //         "cbr" => shiguredo_libvpx::RateControlMode::Cbr,
+    //         "cq" => shiguredo_libvpx::RateControlMode::Cq,
+    //         _ => return Err(nojson::JsonParseError::InvalidValue),
+    //     };
+    // }
+
+    // // 先読みフレーム数
+    // if let Some(lag_in_frames) = params.get("lag_in_frames") {
+    //     if let Ok(lag) = std::num::NonZeroUsize::new(lag_in_frames.to_u64()? as usize) {
+    //         config.lag_in_frames = Some(lag);
+    //     }
+    // }
+
+    // // スレッド数
+    // if let Some(threads) = params.get("threads") {
+    //     if let Ok(thread_count) = std::num::NonZeroUsize::new(threads.to_u64()? as usize) {
+    //         config.threads = Some(thread_count);
+    //     }
+    // }
+
+    // // エラー耐性モード
+    // if let Some(error_resilient) = params.get("error_resilient") {
+    //     config.error_resilient = error_resilient.to_bool()?;
+    // }
+
+    // // キーフレーム間隔
+    // if let Some(keyframe_interval) = params.get("keyframe_interval") {
+    //     if let Ok(interval) = std::num::NonZeroUsize::new(keyframe_interval.to_u64()? as usize) {
+    //         config.keyframe_interval = Some(interval);
+    //     }
+    // }
+
+    // // フレームドロップ閾値
+    // if let Some(frame_drop_threshold) = params.get("frame_drop_threshold") {
+    //     config.frame_drop_threshold = Some(frame_drop_threshold.to_u64()? as usize);
+    // }
+
+    // // 以降はVP8固有の設定
+    // let mut vp8_config = shiguredo_libvpx::Vp8Config {
+    //     noise_sensitivity: None,
+    //     static_threshold: None,
+    //     token_partitions: None,
+    //     max_intra_bitrate_pct: None,
+    //     arnr_config: None,
+    // };
+
+    // if let Some(noise_sensitivity) = params.get("noise_sensitivity") {
+    //     vp8_config.noise_sensitivity = Some(noise_sensitivity.to_i64()? as i32);
+    // }
+
+    // if let Some(static_threshold) = params.get("static_threshold") {
+    //     vp8_config.static_threshold = Some(static_threshold.to_i64()? as i32);
+    // }
+
+    // if let Some(token_partitions) = params.get("token_partitions") {
+    //     vp8_config.token_partitions = Some(token_partitions.to_i64()? as i32);
+    // }
+
+    // if let Some(max_intra_bitrate_pct) = params.get("max_intra_bitrate_pct") {
+    //     vp8_config.max_intra_bitrate_pct = Some(max_intra_bitrate_pct.to_i64()? as i32);
+    // }
+
+    // // ARNR設定
+    // if let Some(arnr_params) = params.get("arnr_config") {
+    //     let arnr_obj = arnr_params.to_object()?;
+    //     let arnr_config = shiguredo_libvpx::ArnrConfig {
+    //         max_frames: arnr_obj
+    //             .get("max_frames")
+    //             .map(|v| v.to_i64())
+    //             .transpose()?
+    //             .unwrap_or(0) as i32,
+    //         strength: arnr_obj
+    //             .get("strength")
+    //             .map(|v| v.to_i64())
+    //             .transpose()?
+    //             .unwrap_or(3) as i32,
+    //         filter_type: arnr_obj
+    //             .get("filter_type")
+    //             .map(|v| v.to_i64())
+    //             .transpose()?
+    //             .unwrap_or(1) as i32,
+    //     };
+    //     vp8_config.arnr_config = Some(arnr_config);
+    // }
+
+    // config.vp8_config = Some(vp8_config);
+
+    Ok(config)
+}
+
+pub fn parse_libvpx_vp9_encode_params(
+    value: nojson::RawJsonValue<'_, '_>,
+) -> Result<shiguredo_libvpx::EncoderConfig, nojson::JsonParseError> {
+    // [NOTE] 以下は後で別途設定するので、ここではパースしない:
+    // - width
+    // - height
+    // - fps_numerator
+    // - fps_denominator
+    // - target_bitrate
+    let params = value.to_object()?;
+    todo!()
+}

--- a/src/encoder_libvpx_params.rs
+++ b/src/encoder_libvpx_params.rs
@@ -51,11 +51,7 @@ pub fn parse_libvpx_vp8_encode_params(
     config.lag_in_frames = params.get("lag_in_frames")?;
 
     // スレッド数
-    if let Some(threads) = params.get("threads")? {
-        if let Some(thread_count) = std::num::NonZeroUsize::new(threads) {
-            config.threads = Some(thread_count);
-        }
-    }
+    config.threads = params.get("threads")?;
 
     // エラー耐性モード
     config.error_resilient = params.get("error_resilient")?.unwrap_or_default();
@@ -102,6 +98,82 @@ pub fn parse_libvpx_vp9_encode_params(
     // - fps_numerator
     // - fps_denominator
     // - target_bitrate
-    let params = value.to_object()?;
-    todo!()
+    let params = JsonObject::new(value)?;
+    let mut config = shiguredo_libvpx::EncoderConfig::default();
+
+    // 基本的なエンコーダーパラメーター
+    config.min_quantizer = params.get("min_quantizer")?.unwrap_or(DEFAULT_MIN_Q);
+    config.max_quantizer = params.get("max_quantizer")?.unwrap_or(DEFAULT_MAX_Q);
+    config.cq_level = params.get("cq_level")?.unwrap_or(DEFAULT_CQ_LEVEL);
+    config.cpu_used = params.get("cpu_used")?;
+
+    // エンコード期限設定
+    if let Some(deadline) =
+        params.get_with("deadline", |v| match v.to_unquoted_string_str()?.as_ref() {
+            "best" => Ok(shiguredo_libvpx::EncodingDeadline::Best),
+            "good" => Ok(shiguredo_libvpx::EncodingDeadline::Good),
+            "realtime" => Ok(shiguredo_libvpx::EncodingDeadline::Realtime),
+            _ => Err(v.invalid("unknown 'deadline' value")),
+        })?
+    {
+        config.deadline = deadline;
+    }
+
+    // レート制御モード
+    if let Some(rate_control) = params.get_with("rate_control", |v| {
+        match v.to_unquoted_string_str()?.as_ref() {
+            "vbr" => Ok(shiguredo_libvpx::RateControlMode::Vbr),
+            "cbr" => Ok(shiguredo_libvpx::RateControlMode::Cbr),
+            "cq" => Ok(shiguredo_libvpx::RateControlMode::Cq),
+            _ => Err(v.invalid("unknown 'rate_control' value")),
+        }
+    })? {
+        config.rate_control = rate_control;
+    }
+
+    // 先読みフレーム数
+    config.lag_in_frames = params.get("lag_in_frames")?;
+
+    // スレッド数
+    config.threads = params.get("threads")?;
+
+    // エラー耐性モード
+    config.error_resilient = params.get("error_resilient")?.unwrap_or_default();
+
+    // キーフレーム間隔
+    config.keyframe_interval = params.get("keyframe_interval")?;
+
+    // フレームドロップ閾値
+    config.frame_drop_threshold = params.get("frame_drop_threshold")?;
+
+    // 以降はVP9固有の設定
+    let mut vp9_config = shiguredo_libvpx::Vp9Config {
+        aq_mode: None,
+        noise_sensitivity: None,
+        tile_columns: None,
+        tile_rows: None,
+        row_mt: false,
+        frame_parallel_decoding: false,
+        tune_content: None,
+    };
+
+    // VP9固有パラメータの設定
+    vp9_config.aq_mode = params.get("aq_mode")?;
+    vp9_config.noise_sensitivity = params.get("noise_sensitivity")?;
+    vp9_config.tile_columns = params.get("tile_columns")?;
+    vp9_config.tile_rows = params.get("tile_rows")?;
+    vp9_config.row_mt = params.get("row_mt")?.unwrap_or_default();
+    vp9_config.frame_parallel_decoding = params.get("frame_parallel_decoding")?.unwrap_or_default();
+
+    // コンテンツタイプ最適化
+    vp9_config.tune_content = params.get_with("tune_content", |v| {
+        match v.to_unquoted_string_str()?.as_ref() {
+            "default" => Ok(shiguredo_libvpx::ContentType::Default),
+            "screen" => Ok(shiguredo_libvpx::ContentType::Screen),
+            _ => Err(v.invalid("unknown 'tune_content' value")),
+        }
+    })?;
+
+    config.vp9_config = Some(vp9_config);
+    Ok(config)
 }

--- a/src/json.rs
+++ b/src/json.rs
@@ -1,0 +1,36 @@
+//! JSON 関連のユーティリティモジュール
+use std::{borrow::Cow, collections::BTreeMap};
+
+#[derive(Debug)]
+pub struct JsonObject<'a, 'text>(BTreeMap<Cow<'text, str>, nojson::RawJsonValue<'text, 'a>>);
+
+impl<'a, 'text> JsonObject<'a, 'text> {
+    pub fn new(value: nojson::RawJsonValue<'text, 'a>) -> Result<Self, nojson::JsonParseError> {
+        Ok(Self(
+            value
+                .to_object()?
+                .map(|(k, v)| Ok((k.to_unquoted_string_str()?, v)))
+                .collect::<Result<_, _>>()?,
+        ))
+    }
+
+    pub fn get<T>(&self, key: &str) -> Result<Option<T>, nojson::JsonParseError>
+    where
+        T: nojson::FromRawJsonValue<'text>,
+    {
+        let Some(value) = self.0.get(key) else {
+            return Ok(None);
+        };
+        Ok(Some(value.try_to()?))
+    }
+
+    pub fn get_with<T, F>(&self, key: &str, f: F) -> Result<Option<T>, nojson::JsonParseError>
+    where
+        F: FnOnce(nojson::RawJsonValue<'text, 'a>) -> Result<T, nojson::JsonParseError>,
+    {
+        let Some(value) = self.0.get(key).copied() else {
+            return Ok(None);
+        };
+        Ok(Some(f(value)?))
+    }
+}

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -43,12 +43,11 @@ pub struct Layout {
 impl Layout {
     /// レイアウト JSON ファイルで指示されたレイアウトを作成する
     pub fn from_layout_json(
+        base_path: PathBuf,
         layout_file_path: &Path,
         json: &str,
         fps: FrameRate,
     ) -> orfail::Result<Self> {
-        let base_path = layout_file_path.parent().or_fail()?.to_path_buf();
-
         let json = nojson::RawJson::parse(json)
             .map_err(|e| malformed_json_error(layout_file_path, json, e))
             .or_fail()?;

--- a/src/layout_encode_params.rs
+++ b/src/layout_encode_params.rs
@@ -1,0 +1,15 @@
+#[derive(Debug, Clone)]
+pub struct LayoutEncodeParams {
+    // TODO: bitrate とかはこっちに移動してもいい
+
+    // LibvpxVp8(shiguredo_libvpx::EncoderConfig),
+    // LibvpxVp9(shiguredo_libvpx::EncoderConfig),
+}
+
+impl<'text> nojson::FromRawJsonValue<'text> for LayoutEncodeParams {
+    fn from_raw_json_value(
+        value: nojson::RawJsonValue<'text, '_>,
+    ) -> Result<Self, nojson::JsonParseError> {
+        todo!()
+    }
+}

--- a/src/layout_encode_params.rs
+++ b/src/layout_encode_params.rs
@@ -1,15 +1,32 @@
-#[derive(Debug, Clone)]
+use crate::encoder_libvpx_params;
+
+#[derive(Debug, Clone, Default)]
 pub struct LayoutEncodeParams {
     // TODO: bitrate とかはこっちに移動してもいい
-
-    // LibvpxVp8(shiguredo_libvpx::EncoderConfig),
-    // LibvpxVp9(shiguredo_libvpx::EncoderConfig),
+    pub libvpx_vp8: Option<shiguredo_libvpx::EncoderConfig>,
+    pub libvpx_vp9: Option<shiguredo_libvpx::EncoderConfig>,
 }
 
 impl<'text> nojson::FromRawJsonValue<'text> for LayoutEncodeParams {
     fn from_raw_json_value(
         value: nojson::RawJsonValue<'text, '_>,
     ) -> Result<Self, nojson::JsonParseError> {
-        todo!()
+        let mut params = Self::default();
+        for (key, value) in value.to_object()? {
+            match &*key.to_unquoted_string_str()? {
+                "libvpx_vp8_encode_params" => {
+                    params.libvpx_vp8 = Some(
+                        encoder_libvpx_params::parse_libvpx_vp8_encode_params(value)?,
+                    );
+                }
+                "libvpx_vp9_encode_params" => {
+                    params.libvpx_vp9 = Some(
+                        encoder_libvpx_params::parse_libvpx_vp9_encode_params(value)?,
+                    );
+                }
+                _ => {}
+            }
+        }
+        Ok(params)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,11 +14,13 @@ pub mod encoder_audio_toolbox;
 #[cfg(feature = "fdk-aac")]
 pub mod encoder_fdk_aac;
 pub mod encoder_libvpx;
+pub mod encoder_libvpx_params;
 pub mod encoder_openh264;
 pub mod encoder_opus;
 pub mod encoder_svt_av1;
 #[cfg(target_os = "macos")]
 pub mod encoder_video_toolbox;
+pub mod json;
 pub mod layout;
 pub mod layout_encode_params;
 pub mod logger;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub mod encoder_svt_av1;
 #[cfg(target_os = "macos")]
 pub mod encoder_video_toolbox;
 pub mod layout;
+pub mod layout_encode_params;
 pub mod logger;
 pub mod metadata;
 pub mod mixer_audio;

--- a/src/subcommand_compose.rs
+++ b/src/subcommand_compose.rs
@@ -6,7 +6,7 @@ use std::{
 use orfail::OrFail;
 use shiguredo_openh264::Openh264Library;
 
-use crate::{composer::Composer, layout::Layout, types::CodecName, video::FrameRate};
+use crate::{composer::Composer, layout::Layout, video::FrameRate};
 
 const DEFAULT_LAYOUT_JSON: &str = r#"{
   "audio_sources": [ "archive*.json" ],
@@ -125,8 +125,6 @@ pub fn run(mut args: noargs::RawArgs) -> noargs::Result<()> {
 
     // Composer を作成して設定
     let mut composer = Composer::new(layout);
-    composer.video_codec = CodecName::Vp8; // デフォルト値
-    composer.audio_codec = CodecName::Opus; // デフォルト値
     composer.openh264_lib = openh264_lib;
     composer.show_progress_bar = !no_progress_bar;
     composer.max_cpu_cores = max_cpu_cores.map(|n| n.get());

--- a/src/subcommand_compose.rs
+++ b/src/subcommand_compose.rs
@@ -148,10 +148,17 @@ fn create_layout(root_dir: &PathBuf, layout_file_path: Option<&Path>) -> orfail:
         // レイアウトファイルが指定された場合
         let layout_json = std::fs::read_to_string(layout_file_path)
             .or_fail_with(|e| format!("failed to read {}: {e}", layout_file_path.display()))?;
-        Layout::from_layout_json(layout_file_path, &layout_json, FrameRate::FPS_25).or_fail()
+        Layout::from_layout_json(
+            root_dir.clone(),
+            layout_file_path,
+            &layout_json,
+            FrameRate::FPS_25,
+        )
+        .or_fail()
     } else {
         // デフォルトレイアウトを作成
         Layout::from_layout_json(
+            root_dir.clone(),
             &root_dir.join("default-layout.json"),
             DEFAULT_LAYOUT_JSON,
             FrameRate::FPS_25,

--- a/src/subcommand_legacy.rs
+++ b/src/subcommand_legacy.rs
@@ -294,8 +294,23 @@ impl Runner {
 
     pub fn run(&mut self) -> orfail::Result<()> {
         // レイアウトを準備
-        let layout = self.create_layout().or_fail()?;
+        let mut layout = self.create_layout().or_fail()?;
         log::debug!("layout: {layout:?}");
+
+        // レガシーではエンコードパラメータの JSON 経由での指定には非対応
+        layout.encode_params = Default::default();
+        layout.encode_params.libvpx_vp8 = Some(shiguredo_libvpx::EncoderConfig {
+            max_quantizer: self.args.libvpx_max_q,
+            min_quantizer: self.args.libvpx_min_q,
+            cq_level: self.args.libvpx_cq_level,
+            ..Default::default()
+        });
+        layout.encode_params.libvpx_vp9 = Some(shiguredo_libvpx::EncoderConfig {
+            max_quantizer: self.args.libvpx_max_q,
+            min_quantizer: self.args.libvpx_min_q,
+            cq_level: self.args.libvpx_cq_level,
+            ..Default::default()
+        });
 
         // 必要に応じて openh264 の共有ライブラリを読み込む
         let openh264_lib =
@@ -322,9 +337,6 @@ impl Runner {
         composer.show_progress_bar = self.args.show_progress_bar;
         composer.max_cpu_cores = self.args.cpu_cores;
         composer.stats_file_path = self.args.out_stats_file.clone();
-        composer.libvpx_cq_level = self.args.libvpx_cq_level;
-        composer.libvpx_min_q = self.args.libvpx_min_q;
-        composer.libvpx_max_q = self.args.libvpx_max_q;
         composer.out_aac_bit_rate = self.args.out_aac_bit_rate;
         composer.out_opus_bit_rate = self.args.out_opus_bit_rate;
 

--- a/src/subcommand_legacy.rs
+++ b/src/subcommand_legacy.rs
@@ -343,7 +343,9 @@ impl Runner {
         if let Some(layout_file_path) = &self.args.layout {
             let layout_json = std::fs::read_to_string(layout_file_path)
                 .or_fail_with(|e| format!("failed to read {}: {e}", layout_file_path.display()))?;
+            let base_path = layout_file_path.parent().or_fail()?.to_path_buf();
             Layout::from_layout_json(
+                base_path,
                 layout_file_path,
                 &layout_json,
                 self.args.out_video_frame_rate,

--- a/src/subcommand_legacy.rs
+++ b/src/subcommand_legacy.rs
@@ -297,6 +297,9 @@ impl Runner {
         let mut layout = self.create_layout().or_fail()?;
         log::debug!("layout: {layout:?}");
 
+        layout.video_codec = self.args.out_video_codec;
+        layout.audio_codec = self.args.out_audio_codec;
+
         // レガシーではエンコードパラメータの JSON 経由での指定には非対応
         layout.encode_params = Default::default();
         layout.encode_params.libvpx_vp8 = Some(shiguredo_libvpx::EncoderConfig {
@@ -331,8 +334,6 @@ impl Runner {
 
         // Composer を作成して設定
         let mut composer = Composer::new(layout);
-        composer.video_codec = self.args.out_video_codec;
-        composer.audio_codec = self.args.out_audio_codec;
         composer.openh264_lib = openh264_lib;
         composer.show_progress_bar = self.args.show_progress_bar;
         composer.max_cpu_cores = self.args.cpu_cores;

--- a/tests/mixer_audio_test.rs
+++ b/tests/mixer_audio_test.rs
@@ -9,6 +9,7 @@ use hisui::{
     metadata::{SourceId, SourceInfo},
     mixer_audio::AudioMixerThread,
     stats::{AudioMixerStats, MixerStats, Seconds, SharedStats, Stats},
+    types::CodecName,
     video::FrameRate,
 };
 use orfail::OrFail;
@@ -390,6 +391,8 @@ fn layout(audio_sources: &[SourceInfo], trim_span: Option<(Duration, Duration)>)
         resolution: Resolution::new(16, 16).expect("infallible"),
         bitrate_kbps: 0,
         fps: FrameRate::FPS_1,
+        audio_codec: CodecName::Opus,
+        video_codec: CodecName::Vp8,
         encode_params: Default::default(),
     }
 }

--- a/tests/mixer_audio_test.rs
+++ b/tests/mixer_audio_test.rs
@@ -390,6 +390,7 @@ fn layout(audio_sources: &[SourceInfo], trim_span: Option<(Duration, Duration)>)
         resolution: Resolution::new(16, 16).expect("infallible"),
         bitrate_kbps: 0,
         fps: FrameRate::FPS_1,
+        encode_params: Default::default(),
     }
 }
 

--- a/tests/mixer_video_test.rs
+++ b/tests/mixer_video_test.rs
@@ -11,7 +11,7 @@ use hisui::{
     metadata::{SourceId, SourceInfo},
     mixer_video::VideoMixerThread,
     stats::{MixerStats, SharedStats, Stats, VideoMixerStats},
-    types::{EvenUsize, PixelPosition},
+    types::{CodecName, EvenUsize, PixelPosition},
     video::{FrameRate, VideoFormat, VideoFrame},
 };
 use orfail::OrFail;
@@ -788,6 +788,8 @@ fn layout(
         audio_source_ids: Default::default(),
         bitrate_kbps: 0,
         fps: FPS,
+        audio_codec: CodecName::Opus,
+        video_codec: CodecName::Vp8,
         encode_params: Default::default(),
     }
 }

--- a/tests/mixer_video_test.rs
+++ b/tests/mixer_video_test.rs
@@ -788,6 +788,7 @@ fn layout(
         audio_source_ids: Default::default(),
         bitrate_kbps: 0,
         fps: FPS,
+        encode_params: Default::default(),
     }
 }
 

--- a/tests/writer_mp4_tests.rs
+++ b/tests/writer_mp4_tests.rs
@@ -5,7 +5,7 @@ use hisui::{
     channel,
     layout::{AggregatedSourceInfo, AssignedSource, Grid, Layout, Region, Resolution},
     metadata::{SourceId, SourceInfo},
-    types::{EvenUsize, PixelPosition},
+    types::{CodecName, EvenUsize, PixelPosition},
     video::{FrameRate, VideoFormat, VideoFrame, VideoFrameReceiver, VideoFrameSyncSender},
     writer_mp4::Mp4Writer,
 };
@@ -188,6 +188,8 @@ fn layout(audio_sources: &[SourceInfo], video_sources: &[SourceInfo]) -> Layout 
         base_path: PathBuf::from(""),
         resolution: Resolution::new(16, 16).expect("infallible"),
         bitrate_kbps: 0,
+        audio_codec: CodecName::Opus,
+        video_codec: CodecName::Vp8,
         encode_params: Default::default(),
     }
 }

--- a/tests/writer_mp4_tests.rs
+++ b/tests/writer_mp4_tests.rs
@@ -188,6 +188,7 @@ fn layout(audio_sources: &[SourceInfo], video_sources: &[SourceInfo]) -> Layout 
         base_path: PathBuf::from(""),
         resolution: Resolution::new(16, 16).expect("infallible"),
         bitrate_kbps: 0,
+        encode_params: Default::default(),
     }
 }
 


### PR DESCRIPTION
This pull request refactors the encoding pipeline by moving codec-specific parameters into a new `LayoutEncodeParams` structure and simplifying the `Composer` and encoder implementations. Additionally, it introduces utility modules for JSON parsing and handling encoding parameters. These changes aim to improve modularity, readability, and maintainability of the codebase.

### Encoding Pipeline Refactor

* **Moved codec-specific parameters to `LayoutEncodeParams`:** The `libvpx_vp8` and `libvpx_vp9` encoding parameters are now stored in the `LayoutEncodeParams` structure, which is part of the `Layout` struct. This change removes hardcoded values from `Composer` and allows encoding parameters to be dynamically configured via JSON. (`src/layout_encode_params.rs`, [[1]](diffhunk://#diff-951236f7ba9430cd983e054a118b645b7d12021bf4a6281d208face3d31f11b8R1-R32); `src/layout.rs`, [[2]](diffhunk://#diff-7937a85ae16def66de428ea5dc339277fc8ca7bb7e40c247dc0b485acc39da6cR36-L47) [[3]](diffhunk://#diff-7937a85ae16def66de428ea5dc339277fc8ca7bb7e40c247dc0b485acc39da6cR299-R301)
* **Simplified encoder constructors:** The `LibvpxEncoder` and `VideoEncoder` constructors now take a `Layout` object instead of individual parameters like `cq_level`, `min_q`, and `max_q`. These values are dynamically derived from `LayoutEncodeParams`. (`src/encoder_libvpx.rs`, [[1]](diffhunk://#diff-49041bfe04f682de9ffea8309b285f8278f9a1eddcb5b37504b5183116280104L36-R45) [[2]](diffhunk://#diff-49041bfe04f682de9ffea8309b285f8278f9a1eddcb5b37504b5183116280104L68-R70); `src/encoder.rs`, [[3]](diffhunk://#diff-9a5ef4cd6ac7a66abd842b474ee88447516ed3bd218748eb6f387a0895d14fcbL121-R127)

### Modularization and Utility Enhancements

* **Added JSON parsing utilities:** Introduced the `JsonObject` struct in the new `json` module to simplify JSON object handling. This utility is used for parsing encoding parameters from JSON input. (`src/json.rs`, [src/json.rsR1-R36](diffhunk://#diff-57424a030625c126c87ec44cfdbae842876da9937a7b7f9a4ac61f3da92ab073R1-R36))
* **Created parameter parsing functions for libvpx:** Added functions to parse VP8 and VP9 encoding parameters from JSON, including support for default values and validation of configuration options such as `rate_control` and `deadline`. (`src/encoder_libvpx_params.rs`, [src/encoder_libvpx_params.rsR1-R179](diffhunk://#diff-736e6e3b0b88309497fbe97d07eee1d2b72aeb74812cca543f33b82279e73007R1-R179))

### Code Cleanup and Simplification

* **Removed redundant fields from `Composer`:** Fields like `libvpx_cq_level`, `libvpx_min_q`, and `libvpx_max_q` were removed from `Composer`, as these are now encapsulated within `LayoutEncodeParams`. (`src/composer.rs`, [[1]](diffhunk://#diff-68750bc7b8422c1504414ba56c6ade1a63d30f530550834c67db7f57679b3c40L27-L37) [[2]](diffhunk://#diff-68750bc7b8422c1504414ba56c6ade1a63d30f530550834c67db7f57679b3c40L52-L62)
* **Updated codec handling in `Composer`:** Audio and video codec handling was refactored to use the `Layout` struct's `audio_codec` and `video_codec` fields instead of separate fields in `Composer`. (`src/composer.rs`, [[1]](diffhunk://#diff-68750bc7b8422c1504414ba56c6ade1a63d30f530550834c67db7f57679b3c40L165-R154) [[2]](diffhunk://#diff-68750bc7b8422c1504414ba56c6ade1a63d30f530550834c67db7f57679b3c40L221-R196)

These changes collectively enhance the flexibility of the encoding pipeline and make the codebase easier to extend and maintain.