### PR TITLE
エンコードパラメーターを JSON 経由で指定可能にする

### DIFF
--- a/src/encoder_libvpx_params.rs
+++ b/src/encoder_libvpx_params.rs
@@ -24,28 +24,26 @@ pub fn parse_vp8_encode_params(
     config.cpu_used = params.get("cpu_used")?;
 
     // エンコード期限設定
-    if let Some(deadline) =
-        params.get_with("deadline", |v| match v.to_unquoted_string_str()?.as_ref() {
+    config.deadline = params
+        .get_with("deadline", |v| match v.to_unquoted_string_str()?.as_ref() {
             "best" => Ok(shiguredo_libvpx::EncodingDeadline::Best),
             "good" => Ok(shiguredo_libvpx::EncodingDeadline::Good),
             "realtime" => Ok(shiguredo_libvpx::EncodingDeadline::Realtime),
             _ => Err(v.invalid("unknown 'deadline' value")),
         })?
-    {
-        config.deadline = deadline;
-    }
+        .unwrap_or(config.deadline);
 
     // レート制御モード
-    if let Some(rate_control) = params.get_with("rate_control", |v| {
-        match v.to_unquoted_string_str()?.as_ref() {
-            "vbr" => Ok(shiguredo_libvpx::RateControlMode::Vbr),
-            "cbr" => Ok(shiguredo_libvpx::RateControlMode::Cbr),
-            "cq" => Ok(shiguredo_libvpx::RateControlMode::Cq),
-            _ => Err(v.invalid("unknown 'rate_control' value")),
-        }
-    })? {
-        config.rate_control = rate_control;
-    }
+    config.rate_control = params
+        .get_with("rate_control", |v| {
+            match v.to_unquoted_string_str()?.as_ref() {
+                "vbr" => Ok(shiguredo_libvpx::RateControlMode::Vbr),
+                "cbr" => Ok(shiguredo_libvpx::RateControlMode::Cbr),
+                "cq" => Ok(shiguredo_libvpx::RateControlMode::Cq),
+                _ => Err(v.invalid("unknown 'rate_control' value")),
+            }
+        })?
+        .unwrap_or(config.rate_control);
 
     // 先読みフレーム数
     config.lag_in_frames = params.get("lag_in_frames")?;
@@ -108,28 +106,26 @@ pub fn parse_vp9_encode_params(
     config.cpu_used = params.get("cpu_used")?;
 
     // エンコード期限設定
-    if let Some(deadline) =
-        params.get_with("deadline", |v| match v.to_unquoted_string_str()?.as_ref() {
+    config.deadline = params
+        .get_with("deadline", |v| match v.to_unquoted_string_str()?.as_ref() {
             "best" => Ok(shiguredo_libvpx::EncodingDeadline::Best),
             "good" => Ok(shiguredo_libvpx::EncodingDeadline::Good),
             "realtime" => Ok(shiguredo_libvpx::EncodingDeadline::Realtime),
             _ => Err(v.invalid("unknown 'deadline' value")),
         })?
-    {
-        config.deadline = deadline;
-    }
+        .unwrap_or(config.deadline);
 
     // レート制御モード
-    if let Some(rate_control) = params.get_with("rate_control", |v| {
-        match v.to_unquoted_string_str()?.as_ref() {
-            "vbr" => Ok(shiguredo_libvpx::RateControlMode::Vbr),
-            "cbr" => Ok(shiguredo_libvpx::RateControlMode::Cbr),
-            "cq" => Ok(shiguredo_libvpx::RateControlMode::Cq),
-            _ => Err(v.invalid("unknown 'rate_control' value")),
-        }
-    })? {
-        config.rate_control = rate_control;
-    }
+    config.rate_control = params
+        .get_with("rate_control", |v| {
+            match v.to_unquoted_string_str()?.as_ref() {
+                "vbr" => Ok(shiguredo_libvpx::RateControlMode::Vbr),
+                "cbr" => Ok(shiguredo_libvpx::RateControlMode::Cbr),
+                "cq" => Ok(shiguredo_libvpx::RateControlMode::Cq),
+                _ => Err(v.invalid("unknown 'rate_control' value")),
+            }
+        })?
+        .unwrap_or(config.rate_control);
 
     // 先読みフレーム数
     config.lag_in_frames = params.get("lag_in_frames")?;

--- a/src/encoder_libvpx_params.rs
+++ b/src/encoder_libvpx_params.rs
@@ -5,7 +5,7 @@ const DEFAULT_CQ_LEVEL: usize = 30;
 const DEFAULT_MIN_Q: usize = 10;
 const DEFAULT_MAX_Q: usize = 50;
 
-pub fn parse_libvpx_vp8_encode_params(
+pub fn parse_vp8_encode_params(
     value: nojson::RawJsonValue<'_, '_>,
 ) -> Result<shiguredo_libvpx::EncoderConfig, nojson::JsonParseError> {
     // [NOTE] 以下は後で別途設定するので、ここではパースしない:
@@ -89,7 +89,7 @@ pub fn parse_libvpx_vp8_encode_params(
     Ok(config)
 }
 
-pub fn parse_libvpx_vp9_encode_params(
+pub fn parse_vp9_encode_params(
     value: nojson::RawJsonValue<'_, '_>,
 ) -> Result<shiguredo_libvpx::EncoderConfig, nojson::JsonParseError> {
     // [NOTE] 以下は後で別途設定するので、ここではパースしない:

--- a/src/encoder_openh264.rs
+++ b/src/encoder_openh264.rs
@@ -31,7 +31,7 @@ impl Openh264Encoder {
             width,
             height,
             target_bitrate: layout.video_bitrate_bps(),
-            ..Default::default()
+            ..layout.encode_params.openh264.clone().unwrap_or_default()
         };
         let inner = shiguredo_openh264::Encoder::new(lib, &config).or_fail()?;
         Ok(Self {

--- a/src/encoder_openh264_params.rs
+++ b/src/encoder_openh264_params.rs
@@ -1,0 +1,97 @@
+use crate::json::JsonObject;
+
+pub fn parse_encode_params(
+    value: nojson::RawJsonValue<'_, '_>,
+) -> Result<shiguredo_openh264::EncoderConfig, nojson::JsonParseError> {
+    // [NOTE] 以下は後で別途設定するので、ここではパースしない:
+    // - width
+    // - height
+    // - fps_numerator
+    // - fps_denominator
+    // - target_bitrate
+    let params = JsonObject::new(value)?;
+    let mut config = shiguredo_openh264::EncoderConfig::default();
+
+    // 基本的なエンコーダーパラメーター
+    config.max_qp = params.get("max_qp")?.unwrap_or(config.max_qp);
+    config.min_qp = params.get("min_qp")?.unwrap_or(config.min_qp);
+
+    // 複雑度モード
+    config.complexity_mode = params
+        .get_with("complexity_mode", |v| {
+            match v.to_unquoted_string_str()?.as_ref() {
+                "low" => Ok(shiguredo_openh264::ComplexityMode::Low),
+                "medium" => Ok(shiguredo_openh264::ComplexityMode::Medium),
+                "high" => Ok(shiguredo_openh264::ComplexityMode::High),
+                _ => Err(v.invalid("unknown 'complexity_mode' value")),
+            }
+        })?
+        .unwrap_or(config.complexity_mode);
+
+    // エントロピー符号化モード
+    config.entropy_coding = params.get("entropy_coding")?.unwrap_or_default();
+
+    // 参照フレーム数
+    config.ref_frame_count = params
+        .get("ref_frame_count")?
+        .unwrap_or(config.ref_frame_count);
+
+    // スレッド数
+    config.thread_count = params.get("thread_count")?;
+
+    // 空間レイヤー数
+    config.spatial_layers = params
+        .get("spatial_layers")?
+        .unwrap_or(config.spatial_layers);
+
+    // 時間レイヤー数
+    config.temporal_layers = params
+        .get("temporal_layers")?
+        .unwrap_or(config.temporal_layers);
+
+    // Intra フレーム間隔
+    config.intra_period = params.get("intra_period")?;
+
+    // レート制御モード
+    config.rate_control_mode = params
+        .get_with("rate_control_mode", |v| {
+            match v.to_unquoted_string_str()?.as_ref() {
+                "off" => Ok(shiguredo_openh264::RateControlMode::Off),
+                "quality" => Ok(shiguredo_openh264::RateControlMode::Quality),
+                "bitrate" => Ok(shiguredo_openh264::RateControlMode::Bitrate),
+                "timestamp" => Ok(shiguredo_openh264::RateControlMode::Timestamp),
+                _ => Err(v.invalid("unknown 'rate_control_mode' value")),
+            }
+        })?
+        .unwrap_or(config.rate_control_mode);
+
+    // 前処理機能設定
+    config.denoise = params.get("denoise")?.unwrap_or_default();
+    config.background_detection = params.get("background_detection")?.unwrap_or_default();
+    config.adaptive_quantization = params.get("adaptive_quantization")?.unwrap_or_default();
+    config.scene_change_detection = params.get("scene_change_detection")?.unwrap_or_default();
+    config.deblocking_filter = params.get("deblocking_filter")?.unwrap_or_default();
+    config.long_term_reference = params.get("long_term_reference")?.unwrap_or_default();
+
+    // スライスモード
+    config.slice_mode = params
+        .get_with("slice_mode", |v| {
+            let slice_obj = JsonObject::new(v)?;
+            let mode_type: String = slice_obj.get_required("type")?;
+            match mode_type.as_str() {
+                "single" => Ok(shiguredo_openh264::SliceMode::Single),
+                "fixed_count" => {
+                    let count = slice_obj.get_required("count")?;
+                    Ok(shiguredo_openh264::SliceMode::FixedCount(count))
+                }
+                "size_constrained" => {
+                    let size = slice_obj.get_required("size")?;
+                    Ok(shiguredo_openh264::SliceMode::SizeConstrained(size))
+                }
+                _ => Err(v.invalid("unknown 'slice_mode.type' value")),
+            }
+        })?
+        .unwrap_or(config.slice_mode);
+
+    Ok(config)
+}

--- a/src/encoder_svt_av1.rs
+++ b/src/encoder_svt_av1.rs
@@ -32,7 +32,7 @@ impl SvtAv1Encoder {
             height: height.get(),
             fps_numerator: layout.fps.numerator.get(),
             fps_denominator: layout.fps.denumerator.get(),
-            ..Default::default()
+            ..layout.encode_params.svt_av1.clone().unwrap_or_default()
         };
         let inner = shiguredo_svt_av1::Encoder::new(&config).or_fail()?;
         let sample_entry = sample_entry(width, height, inner.extra_data());

--- a/src/encoder_svt_av1_params.rs
+++ b/src/encoder_svt_av1_params.rs
@@ -1,0 +1,109 @@
+use crate::json::JsonObject;
+
+pub fn parse_encode_params(
+    value: nojson::RawJsonValue<'_, '_>,
+) -> Result<shiguredo_svt_av1::EncoderConfig, nojson::JsonParseError> {
+    // [NOTE] 以下は後で別途設定するので、ここではパースしない:
+    // - width
+    // - height
+    // - fps_numerator
+    // - fps_denominator
+    // - target_bitrate
+    let params = JsonObject::new(value)?;
+    let mut config = shiguredo_svt_av1::EncoderConfig::default();
+
+    // === 品質・速度制御関連 ===
+    config.enc_mode = params.get("enc_mode")?.unwrap_or(config.enc_mode);
+    config.qp = params.get("qp")?;
+    config.min_qp_allowed = params.get("min_qp_allowed")?;
+    config.max_qp_allowed = params.get("max_qp_allowed")?;
+
+    // === レート制御関連 ===
+    config.rate_control_mode = params
+        .get_with("rate_control_mode", |v| {
+            match v.to_unquoted_string_str()?.as_ref() {
+                "cqp" | "crf" => Ok(shiguredo_svt_av1::RateControlMode::CqpOrCrf),
+                "vbr" => Ok(shiguredo_svt_av1::RateControlMode::Vbr),
+                "cbr" => Ok(shiguredo_svt_av1::RateControlMode::Cbr),
+                _ => Err(v.invalid("unknown 'rate_control_mode' value")),
+            }
+        })?
+        .unwrap_or(config.rate_control_mode);
+
+    config.max_bit_rate = params.get("max_bit_rate")?;
+    config.over_shoot_pct = params
+        .get("over_shoot_pct")?
+        .unwrap_or(config.over_shoot_pct);
+    config.under_shoot_pct = params
+        .get("under_shoot_pct")?
+        .unwrap_or(config.under_shoot_pct);
+
+    // === GOP・フレーム構造関連 ===
+    config.intra_period_length = params
+        .get("intra_period_length")?
+        .unwrap_or(config.intra_period_length);
+    config.hierarchical_levels = params
+        .get("hierarchical_levels")?
+        .unwrap_or(config.hierarchical_levels);
+    config.pred_structure = params
+        .get("pred_structure")?
+        .unwrap_or(config.pred_structure);
+    config.scene_change_detection = params
+        .get("scene_change_detection")?
+        .unwrap_or(config.scene_change_detection);
+    config.look_ahead_distance = params
+        .get("look_ahead_distance")?
+        .unwrap_or(config.look_ahead_distance);
+
+    // === 並列処理関連 ===
+    config.pin_threads = params.get("pin_threads")?;
+    config.tile_columns = params.get("tile_columns")?;
+    config.tile_rows = params.get("tile_rows")?;
+    config.target_socket = params.get("target_socket")?.unwrap_or(config.target_socket);
+
+    // === フィルタリング関連 ===
+    config.enable_dlf_flag = params
+        .get("enable_dlf_flag")?
+        .unwrap_or(config.enable_dlf_flag);
+    config.cdef_level = params.get("cdef_level")?.unwrap_or(config.cdef_level);
+    config.enable_restoration_filtering = params
+        .get("enable_restoration_filtering")?
+        .unwrap_or(config.enable_restoration_filtering);
+
+    // === 高度な設定 ===
+    config.enable_tf = params.get("enable_tf")?.unwrap_or(config.enable_tf);
+    config.enable_overlays = params
+        .get("enable_overlays")?
+        .unwrap_or(config.enable_overlays);
+    config.film_grain_denoise_strength = params.get("film_grain_denoise_strength")?;
+    config.enable_tpl_la = params.get("enable_tpl_la")?.unwrap_or(config.enable_tpl_la);
+    config.force_key_frames = params
+        .get("force_key_frames")?
+        .unwrap_or(config.force_key_frames);
+    config.stat_report = params.get("stat_report")?.unwrap_or(config.stat_report);
+    config.recon_enabled = params.get("recon_enabled")?.unwrap_or(config.recon_enabled);
+
+    // === エンコーダー固有設定 ===
+    config.encoder_bit_depth = params
+        .get("encoder_bit_depth")?
+        .unwrap_or(config.encoder_bit_depth);
+
+    config.encoder_color_format = params
+        .get_with("encoder_color_format", |v| {
+            match v.to_unquoted_string_str()?.as_ref() {
+                "yuv400" => Ok(shiguredo_svt_av1::ColorFormat::Yuv400),
+                "yuv420" => Ok(shiguredo_svt_av1::ColorFormat::Yuv420),
+                "yuv422" => Ok(shiguredo_svt_av1::ColorFormat::Yuv422),
+                "yuv444" => Ok(shiguredo_svt_av1::ColorFormat::Yuv444),
+                _ => Err(v.invalid("unknown 'encoder_color_format' value")),
+            }
+        })?
+        .unwrap_or(config.encoder_color_format);
+
+    config.profile = params.get("profile")?.unwrap_or(config.profile);
+    config.level = params.get("level")?.unwrap_or(config.level);
+    config.tier = params.get("tier")?.unwrap_or(config.tier);
+    config.fast_decode = params.get("fast_decode")?.unwrap_or(config.fast_decode);
+
+    Ok(config)
+}

--- a/src/encoder_video_toolbox.rs
+++ b/src/encoder_video_toolbox.rs
@@ -38,7 +38,11 @@ impl VideoToolboxEncoder {
             target_bitrate: layout.video_bitrate_bps(),
             fps_numerator: layout.fps.numerator.get(),
             fps_denominator: layout.fps.denumerator.get(),
-            ..Default::default()
+            ..layout
+                .encode_params
+                .video_toolbox_h264
+                .clone()
+                .unwrap_or_default()
         };
         let inner = shiguredo_video_toolbox::Encoder::new_h264(&config).or_fail()?;
         Ok(Self {
@@ -62,8 +66,11 @@ impl VideoToolboxEncoder {
             target_bitrate: layout.video_bitrate_bps(),
             fps_numerator: layout.fps.numerator.get(),
             fps_denominator: layout.fps.denumerator.get(),
-            profile_level: shiguredo_video_toolbox::ProfileLevel::H265Main,
-            ..Default::default()
+            ..layout
+                .encode_params
+                .video_toolbox_h265
+                .clone()
+                .unwrap_or_default()
         };
         let inner = shiguredo_video_toolbox::Encoder::new_h265(&config).or_fail()?;
         Ok(Self {

--- a/src/encoder_video_toolbox_params.rs
+++ b/src/encoder_video_toolbox_params.rs
@@ -1,0 +1,168 @@
+use crate::json::JsonObject;
+use shiguredo_video_toolbox::{EncoderConfig, H264EntropyMode, ProfileLevel};
+use std::time::Duration;
+
+pub fn parse_h264_encode_params(
+    value: nojson::RawJsonValue<'_, '_>,
+) -> Result<EncoderConfig, nojson::JsonParseError> {
+    // [NOTE] 以下は後で別途設定するので、ここではパースしない:
+    // - width
+    // - height
+    // - fps_numerator
+    // - fps_denominator
+    // - target_bitrate
+    let params = JsonObject::new(value)?;
+    let mut config = EncoderConfig::default();
+
+    // 品質設定
+    config.quality = params.get("quality")?;
+
+    // 速度と品質のバランス設定
+    if let Some(prioritize_speed) = params.get("prioritize_speed_over_quality")? {
+        config.prioritize_speed_over_quality = prioritize_speed;
+    }
+    if let Some(real_time) = params.get("real_time")? {
+        config.real_time = real_time;
+    }
+    if let Some(maximize_power) = params.get("maximize_power_efficiency")? {
+        config.maximize_power_efficiency = maximize_power;
+    }
+
+    // フレーム構造設定
+    if let Some(allow_reordering) = params.get("allow_frame_reordering")? {
+        config.allow_frame_reordering = allow_reordering;
+    }
+    if let Some(allow_open_gop) = params.get("allow_open_gop")? {
+        config.allow_open_gop = allow_open_gop;
+    }
+    if let Some(allow_temporal) = params.get("allow_temporal_compression")? {
+        config.allow_temporal_compression = allow_temporal;
+    }
+
+    // キーフレーム間隔設定（フレーム数）
+    config.max_key_frame_interval = params.get("max_key_frame_interval")?;
+
+    // キーフレーム間隔設定（秒数）
+    config.max_key_frame_interval_duration = params
+        .get_with("max_key_frame_interval_duration", |v| {
+            Ok(Duration::from_secs_f64(v.try_to()?))
+        })?;
+
+    // プロファイルレベル設定
+    config.profile_level = params
+        .get_with("profile_level", |v| {
+            match v.to_unquoted_string_str()?.as_ref() {
+                "baseline" => Ok(ProfileLevel::H264Baseline),
+                "main" => Ok(ProfileLevel::H264Main),
+                "high" => Ok(ProfileLevel::H264High),
+                _ => Err(v.invalid("unknown 'profile_level' value for H.264")),
+            }
+        })?
+        .unwrap_or(config.profile_level);
+
+    // H.264エントロピー符号化モード
+    config.h264_entropy_mode = params
+        .get_with("h264_entropy_mode", |v| {
+            match v.to_unquoted_string_str()?.as_ref() {
+                "cavlc" => Ok(H264EntropyMode::Cavlc),
+                "cabac" => Ok(H264EntropyMode::Cabac),
+                _ => Err(v.invalid("unknown 'h264_entropy_mode' value")),
+            }
+        })?
+        .unwrap_or(config.h264_entropy_mode);
+
+    // フレーム遅延制限
+    config.max_frame_delay_count = params.get("max_frame_delay_count")?;
+
+    // 並列処理設定
+    config.use_parallelization = params.get("use_parallelization")?.unwrap_or_default();
+
+    Ok(config)
+}
+
+pub fn parse_h265_encode_params(
+    value: nojson::RawJsonValue<'_, '_>,
+) -> Result<EncoderConfig, nojson::JsonParseError> {
+    // [NOTE] 以下は後で別途設定するので、ここではパースしない:
+    // - width
+    // - height
+    // - fps_numerator
+    // - fps_denominator
+    // - target_bitrate
+    let params = JsonObject::new(value)?;
+    let mut config = EncoderConfig::default();
+
+    // H.265用のデフォルト設定
+    config.profile_level = ProfileLevel::H265Main;
+
+    // 基本的なエンコーダーパラメーター
+    if let Some(bitrate) = params.get("target_bitrate")? {
+        config.target_bitrate = bitrate;
+    }
+    if let Some(fps_num) = params.get("fps_numerator")? {
+        config.fps_numerator = fps_num;
+    }
+    if let Some(fps_den) = params.get("fps_denominator")? {
+        config.fps_denominator = fps_den;
+    }
+
+    // 品質設定
+    config.quality = params.get_with("quality", |v| {
+        let q: f32 = v.try_to()?;
+        if 0.0 <= q && q <= 1.0 {
+            Ok(q)
+        } else {
+            Err(v.invalid("quality must be between 0.0 and 1.0"))
+        }
+    })?;
+
+    // 速度と品質のバランス設定
+    if let Some(prioritize_speed) = params.get("prioritize_speed_over_quality")? {
+        config.prioritize_speed_over_quality = prioritize_speed;
+    }
+    if let Some(real_time) = params.get("real_time")? {
+        config.real_time = real_time;
+    }
+    if let Some(maximize_power) = params.get("maximize_power_efficiency")? {
+        config.maximize_power_efficiency = maximize_power;
+    }
+
+    // フレーム構造設定
+    if let Some(allow_reordering) = params.get("allow_frame_reordering")? {
+        config.allow_frame_reordering = allow_reordering;
+    }
+    if let Some(allow_open_gop) = params.get("allow_open_gop")? {
+        config.allow_open_gop = allow_open_gop;
+    }
+    if let Some(allow_temporal) = params.get("allow_temporal_compression")? {
+        config.allow_temporal_compression = allow_temporal;
+    }
+
+    // キーフレーム間隔設定（フレーム数）
+    config.max_key_frame_interval = params.get("max_key_frame_interval")?;
+
+    // キーフレーム間隔設定（秒数）
+    config.max_key_frame_interval_duration = params
+        .get_with("max_key_frame_interval_duration", |v| {
+            Ok(Duration::from_secs_f64(v.try_to()?))
+        })?;
+
+    // プロファイルレベル設定（H.265用）
+    config.profile_level = params
+        .get_with("profile_level", |v| {
+            match v.to_unquoted_string_str()?.as_ref() {
+                "main" => Ok(ProfileLevel::H265Main),
+                "main10" => Ok(ProfileLevel::H265Main10),
+                _ => Err(v.invalid("unknown 'profile_level' value for H.265")),
+            }
+        })?
+        .unwrap_or(config.profile_level);
+
+    // フレーム遅延制限
+    config.max_frame_delay_count = params.get("max_frame_delay_count")?;
+
+    // 並列処理設定
+    config.use_parallelization = params.get("use_parallelization")?.unwrap_or_default();
+
+    Ok(config)
+}

--- a/src/json.rs
+++ b/src/json.rs
@@ -2,33 +2,49 @@
 use std::{borrow::Cow, collections::BTreeMap};
 
 #[derive(Debug)]
-pub struct JsonObject<'a, 'text>(BTreeMap<Cow<'text, str>, nojson::RawJsonValue<'text, 'a>>);
+pub struct JsonObject<'a, 'text> {
+    object: nojson::RawJsonValue<'text, 'a>,
+    members: BTreeMap<Cow<'text, str>, nojson::RawJsonValue<'text, 'a>>,
+}
 
 impl<'a, 'text> JsonObject<'a, 'text> {
     pub fn new(value: nojson::RawJsonValue<'text, 'a>) -> Result<Self, nojson::JsonParseError> {
-        Ok(Self(
-            value
+        Ok(Self {
+            object: value,
+            members: value
                 .to_object()?
                 .map(|(k, v)| Ok((k.to_unquoted_string_str()?, v)))
                 .collect::<Result<_, _>>()?,
-        ))
+        })
     }
 
     pub fn get<T>(&self, key: &str) -> Result<Option<T>, nojson::JsonParseError>
     where
         T: nojson::FromRawJsonValue<'text>,
     {
-        let Some(value) = self.0.get(key) else {
+        let Some(value) = self.members.get(key) else {
             return Ok(None);
         };
         Ok(Some(value.try_to()?))
+    }
+
+    pub fn get_required<T>(&self, key: &str) -> Result<T, nojson::JsonParseError>
+    where
+        T: nojson::FromRawJsonValue<'text>,
+    {
+        let Some(value) = self.members.get(key) else {
+            return Err(self
+                .object
+                .invalid(format!("missing required member {key:?}")));
+        };
+        value.try_to()
     }
 
     pub fn get_with<T, F>(&self, key: &str, f: F) -> Result<Option<T>, nojson::JsonParseError>
     where
         F: FnOnce(nojson::RawJsonValue<'text, 'a>) -> Result<T, nojson::JsonParseError>,
     {
-        let Some(value) = self.0.get(key).copied() else {
+        let Some(value) = self.members.get(key).copied() else {
             return Ok(None);
         };
         Ok(Some(f(value)?))

--- a/src/layout_encode_params.rs
+++ b/src/layout_encode_params.rs
@@ -1,4 +1,7 @@
-use crate::{encoder_libvpx_params, encoder_openh264_params, encoder_svt_av1_params};
+use crate::{
+    encoder_libvpx_params, encoder_openh264_params, encoder_svt_av1_params,
+    encoder_video_toolbox_params,
+};
 
 #[derive(Debug, Clone, Default)]
 pub struct LayoutEncodeParams {
@@ -7,6 +10,8 @@ pub struct LayoutEncodeParams {
     pub libvpx_vp9: Option<shiguredo_libvpx::EncoderConfig>,
     pub openh264: Option<shiguredo_openh264::EncoderConfig>,
     pub svt_av1: Option<shiguredo_svt_av1::EncoderConfig>,
+    pub video_toolbox_h264: Option<shiguredo_video_toolbox::EncoderConfig>,
+    pub video_toolbox_h265: Option<shiguredo_video_toolbox::EncoderConfig>,
 }
 
 impl<'text> nojson::FromRawJsonValue<'text> for LayoutEncodeParams {
@@ -29,6 +34,16 @@ impl<'text> nojson::FromRawJsonValue<'text> for LayoutEncodeParams {
                 }
                 "svt_av1_encode_params" => {
                     params.svt_av1 = Some(encoder_svt_av1_params::parse_encode_params(value)?);
+                }
+                "video_toolbox_h264_encode_params" => {
+                    params.video_toolbox_h264 = Some(
+                        encoder_video_toolbox_params::parse_h264_encode_params(value)?,
+                    );
+                }
+                "video_toolbox_h265_encode_params" => {
+                    params.video_toolbox_h265 = Some(
+                        encoder_video_toolbox_params::parse_h265_encode_params(value)?,
+                    );
                 }
                 _ => {}
             }

--- a/src/layout_encode_params.rs
+++ b/src/layout_encode_params.rs
@@ -1,7 +1,6 @@
-use crate::{
-    encoder_libvpx_params, encoder_openh264_params, encoder_svt_av1_params,
-    encoder_video_toolbox_params,
-};
+#[cfg(target_os = "macos")]
+use crate::encoder_video_toolbox_params;
+use crate::{encoder_libvpx_params, encoder_openh264_params, encoder_svt_av1_params};
 
 #[derive(Debug, Clone, Default)]
 pub struct LayoutEncodeParams {

--- a/src/layout_encode_params.rs
+++ b/src/layout_encode_params.rs
@@ -1,4 +1,4 @@
-use crate::{encoder_libvpx_params, encoder_openh264_params};
+use crate::{encoder_libvpx_params, encoder_openh264_params, encoder_svt_av1_params};
 
 #[derive(Debug, Clone, Default)]
 pub struct LayoutEncodeParams {
@@ -6,6 +6,7 @@ pub struct LayoutEncodeParams {
     pub libvpx_vp8: Option<shiguredo_libvpx::EncoderConfig>,
     pub libvpx_vp9: Option<shiguredo_libvpx::EncoderConfig>,
     pub openh264: Option<shiguredo_openh264::EncoderConfig>,
+    pub svt_av1: Option<shiguredo_svt_av1::EncoderConfig>,
 }
 
 impl<'text> nojson::FromRawJsonValue<'text> for LayoutEncodeParams {
@@ -25,6 +26,9 @@ impl<'text> nojson::FromRawJsonValue<'text> for LayoutEncodeParams {
                 }
                 "openh264_encode_params" => {
                     params.openh264 = Some(encoder_openh264_params::parse_encode_params(value)?);
+                }
+                "svt_av1_encode_params" => {
+                    params.svt_av1 = Some(encoder_svt_av1_params::parse_encode_params(value)?);
                 }
                 _ => {}
             }

--- a/src/layout_encode_params.rs
+++ b/src/layout_encode_params.rs
@@ -10,7 +10,9 @@ pub struct LayoutEncodeParams {
     pub libvpx_vp9: Option<shiguredo_libvpx::EncoderConfig>,
     pub openh264: Option<shiguredo_openh264::EncoderConfig>,
     pub svt_av1: Option<shiguredo_svt_av1::EncoderConfig>,
+    #[cfg(target_os = "macos")]
     pub video_toolbox_h264: Option<shiguredo_video_toolbox::EncoderConfig>,
+    #[cfg(target_os = "macos")]
     pub video_toolbox_h265: Option<shiguredo_video_toolbox::EncoderConfig>,
 }
 
@@ -35,11 +37,13 @@ impl<'text> nojson::FromRawJsonValue<'text> for LayoutEncodeParams {
                 "svt_av1_encode_params" => {
                     params.svt_av1 = Some(encoder_svt_av1_params::parse_encode_params(value)?);
                 }
+                #[cfg(target_os = "macos")]
                 "video_toolbox_h264_encode_params" => {
                     params.video_toolbox_h264 = Some(
                         encoder_video_toolbox_params::parse_h264_encode_params(value)?,
                     );
                 }
+                #[cfg(target_os = "macos")]
                 "video_toolbox_h265_encode_params" => {
                     params.video_toolbox_h265 = Some(
                         encoder_video_toolbox_params::parse_h265_encode_params(value)?,

--- a/src/layout_encode_params.rs
+++ b/src/layout_encode_params.rs
@@ -1,10 +1,11 @@
-use crate::encoder_libvpx_params;
+use crate::{encoder_libvpx_params, encoder_openh264_params};
 
 #[derive(Debug, Clone, Default)]
 pub struct LayoutEncodeParams {
     // TODO: bitrate とかはこっちに移動してもいい
     pub libvpx_vp8: Option<shiguredo_libvpx::EncoderConfig>,
     pub libvpx_vp9: Option<shiguredo_libvpx::EncoderConfig>,
+    pub openh264: Option<shiguredo_openh264::EncoderConfig>,
 }
 
 impl<'text> nojson::FromRawJsonValue<'text> for LayoutEncodeParams {
@@ -15,14 +16,15 @@ impl<'text> nojson::FromRawJsonValue<'text> for LayoutEncodeParams {
         for (key, value) in value.to_object()? {
             match &*key.to_unquoted_string_str()? {
                 "libvpx_vp8_encode_params" => {
-                    params.libvpx_vp8 = Some(
-                        encoder_libvpx_params::parse_libvpx_vp8_encode_params(value)?,
-                    );
+                    params.libvpx_vp8 =
+                        Some(encoder_libvpx_params::parse_vp8_encode_params(value)?);
                 }
                 "libvpx_vp9_encode_params" => {
-                    params.libvpx_vp9 = Some(
-                        encoder_libvpx_params::parse_libvpx_vp9_encode_params(value)?,
-                    );
+                    params.libvpx_vp9 =
+                        Some(encoder_libvpx_params::parse_vp9_encode_params(value)?);
+                }
+                "openh264_encode_params" => {
+                    params.openh264 = Some(encoder_openh264_params::parse_encode_params(value)?);
                 }
                 _ => {}
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub mod encoder_svt_av1;
 pub mod encoder_svt_av1_params;
 #[cfg(target_os = "macos")]
 pub mod encoder_video_toolbox;
+pub mod encoder_video_toolbox_params;
 pub mod json;
 pub mod layout;
 pub mod layout_encode_params;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub mod encoder_openh264;
 pub mod encoder_openh264_params;
 pub mod encoder_opus;
 pub mod encoder_svt_av1;
+pub mod encoder_svt_av1_params;
 #[cfg(target_os = "macos")]
 pub mod encoder_video_toolbox;
 pub mod json;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub mod encoder_svt_av1;
 pub mod encoder_svt_av1_params;
 #[cfg(target_os = "macos")]
 pub mod encoder_video_toolbox;
+#[cfg(target_os = "macos")]
 pub mod encoder_video_toolbox_params;
 pub mod json;
 pub mod layout;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod encoder_fdk_aac;
 pub mod encoder_libvpx;
 pub mod encoder_libvpx_params;
 pub mod encoder_openh264;
+pub mod encoder_openh264_params;
 pub mod encoder_opus;
 pub mod encoder_svt_av1;
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
This pull request introduces significant improvements to the encoder configuration parsing and layout handling across multiple codecs. The changes streamline parameter parsing, enhance flexibility by supporting optional configurations, and improve error handling for required parameters. Additionally, the `JsonObject` structure has been refactored to better manage JSON objects and their members.

### Encoder Configuration Parsing Enhancements:
* **VP8 and VP9 Encoder Parameters**: Refactored `parse_libvpx_vp8_encode_params` and `parse_libvpx_vp9_encode_params` functions to directly set configuration fields using `unwrap_or` for optional parameters, simplifying the logic. Function names were also updated for consistency (`[[1]](diffhunk://#diff-736e6e3b0b88309497fbe97d07eee1d2b72aeb74812cca543f33b82279e73007L8-R8)`, `[[2]](diffhunk://#diff-736e6e3b0b88309497fbe97d07eee1d2b72aeb74812cca543f33b82279e73007L27-R46)`, `[[3]](diffhunk://#diff-736e6e3b0b88309497fbe97d07eee1d2b72aeb74812cca543f33b82279e73007L92-R90)`, `[[4]](diffhunk://#diff-736e6e3b0b88309497fbe97d07eee1d2b72aeb74812cca543f33b82279e73007L111-R128)`).
* **OpenH264 Encoder Parameters**: Added `parse_encode_params` for OpenH264, supporting a comprehensive set of parameters such as complexity mode, entropy coding, and slice mode (`[src/encoder_openh264_params.rsR1-R97](diffhunk://#diff-63432c33b757942cdfe725cd19218153314503f677ae4a6f943ee71624178295R1-R97)`).
* **SVT-AV1 Encoder Parameters**: Introduced `parse_encode_params` for SVT-AV1, enabling detailed configuration for quality, rate control, GOP structure, and advanced settings (`[src/encoder_svt_av1_params.rsR1-R109](diffhunk://#diff-3e3fb8b0b30f8c126fe6882c1da4600ff32d041fb97bb90a6b6f735e08dcdc6cR1-R109)`).
* **VideoToolbox Encoder Parameters**: Added `parse_h264_encode_params` and `parse_h265_encode_params` for macOS-specific VideoToolbox encoders, covering quality, frame structure, and parallelization settings (`[src/encoder_video_toolbox_params.rsR1-R168](diffhunk://#diff-562d7e4957b66f3bcafcfb6c7ee5275c8fbf2302e52c2978837444214a16b4bcR1-R168)`).

### Layout Handling Improvements:
* **Flexible Encoder Layout**: Updated `LayoutEncodeParams` to support optional configurations for OpenH264, SVT-AV1, and macOS-specific VideoToolbox encoders, improving adaptability to various encoding scenarios (`[src/layout_encode_params.rsL1-R15](diffhunk://#diff-951236f7ba9430cd983e054a118b645b7d12021bf4a6281d208face3d31f11b8L1-R15)`).
* **Default Configuration Handling**: Modified encoder initialization (`Openh264Encoder`, `SvtAv1Encoder`, `VideoToolboxEncoder`) to use optional layout parameters with `unwrap_or_default` for fallback values (`[[1]](diffhunk://#diff-98cd0c71cf609268f1f72ac5e5abd3c609317868415373ba10e556b9ee51c547L34-R34)`, `[[2]](diffhunk://#diff-b4e9412c8d0a3974522791d0c5a43a029d891f127a36ad36f31c06e9ab9cf2c0L35-R35)`, `[[3]](diffhunk://#diff-423319f2d100c0dd9f6ed9cefff9e07a47d478df58efd4c3af4d987e0d242757L41-R45)`, `[[4]](diffhunk://#diff-423319f2d100c0dd9f6ed9cefff9e07a47d478df58efd4c3af4d987e0d242757L65-R73)`).

### JSON Object Refactoring:
* **Improved `JsonObject` Structure**: Refactored `JsonObject` to separate the raw object and its members, added a new `get_required` method for mandatory parameter retrieval, and enhanced error handling for missing keys (`[src/json.rsL5-R47](diffhunk://#diff-57424a030625c126c87ec44cfdbae842876da9937a7b7f9a4ac61f3da92ab073L5-R47)`).