### PR TITLE
リージョンの背景色を指定可能にする（開発者向け）

### DIFF
--- a/src/encoder_video_toolbox.rs
+++ b/src/encoder_video_toolbox.rs
@@ -2,8 +2,8 @@ use std::collections::VecDeque;
 
 use orfail::OrFail;
 use shiguredo_mp4::{
-    boxes::{Avc1Box, AvccBox, Hev1Box, HvccBox, HvccNalUintArray, SampleEntry},
     Uint,
+    boxes::{Avc1Box, AvccBox, Hev1Box, HvccBox, HvccNalUintArray, SampleEntry},
 };
 use shiguredo_video_toolbox::{EncoderConfig, ProfileLevel};
 

--- a/src/layout_region.rs
+++ b/src/layout_region.rs
@@ -77,7 +77,7 @@ pub struct RawRegion {
     x_pos: usize,
     y_pos: usize,
     z_pos: isize,
-    //以降は開発者向けの undoc 項目
+    // 以降は開発者向けの undoc 項目
     background_color: [u8; 3], // RGB
 }
 

--- a/src/layout_region.rs
+++ b/src/layout_region.rs
@@ -29,6 +29,7 @@ pub struct Region {
     pub z_pos: isize,
     pub top_border_pixels: EvenUsize,
     pub left_border_pixels: EvenUsize,
+    pub background_color: [u8; 3], // RGB
 }
 
 impl Region {
@@ -76,6 +77,8 @@ pub struct RawRegion {
     x_pos: usize,
     y_pos: usize,
     z_pos: isize,
+    //以降は開発者向けの undoc 項目
+    background_color: [u8; 3], // RGB
 }
 
 impl<'text, 'raw> TryFrom<nojson::RawJsonValue<'text, 'raw>> for RawRegion {
@@ -97,6 +100,7 @@ impl<'text, 'raw> TryFrom<nojson::RawJsonValue<'text, 'raw>> for RawRegion {
             x_pos: object.get("x_pos")?.unwrap_or_default(),
             y_pos: object.get("y_pos")?.unwrap_or_default(),
             z_pos: object.get("z_pos")?.unwrap_or_default(),
+            background_color: object.get("background_color")?.unwrap_or_default(),
         })
     }
 }
@@ -266,6 +270,7 @@ impl RawRegion {
             z_pos: self.z_pos,
             top_border_pixels,
             left_border_pixels,
+            background_color: self.background_color,
         })
     }
 

--- a/src/layout_region.rs
+++ b/src/layout_region.rs
@@ -78,7 +78,7 @@ pub struct RawRegion {
     y_pos: usize,
     z_pos: isize,
     // 以降は開発者向けの undoc 項目
-    background_color: [u8; 3], // RGB
+    background_color: [u8; 3], // RGB (デフォルトは `[0, 0, 0]`）
 }
 
 impl<'text, 'raw> TryFrom<nojson::RawJsonValue<'text, 'raw>> for RawRegion {

--- a/src/mixer_video.rs
+++ b/src/mixer_video.rs
@@ -277,7 +277,8 @@ impl VideoMixerThread {
     ) -> orfail::Result<()> {
         // [NOTE] ここで実質的にやりたいのは外枠を引くことだけなので、リージョン全体を塗りつぶすのは少し過剰
         //        (必要に応じて最適化する)
-        let background_frame = VideoFrame::black(region.width, region.height);
+        let background_frame =
+            VideoFrame::mono_color(region.background_color, region.width, region.height);
         canvas
             .draw_frame(region.position, &background_frame)
             .or_fail()?;

--- a/src/reader_mp4.rs
+++ b/src/reader_mp4.rs
@@ -8,9 +8,9 @@ use std::{
 
 use orfail::OrFail;
 use shiguredo_mp4::{
+    Decode, Either,
     aux::SampleTableAccessor,
     boxes::{FtypBox, HdlrBox, IgnoredBox, MoovBox, SampleEntry, StblBox, TrakBox},
-    Decode, Either,
 };
 
 use crate::{

--- a/src/video.rs
+++ b/src/video.rs
@@ -86,12 +86,12 @@ impl VideoFrame {
             return Self::black(width, height);
         }
 
-        // Convert RGB to YUV
+        // RGB から YUV に変換
         let r = rgb[0] as f32;
         let g = rgb[1] as f32;
         let b = rgb[2] as f32;
 
-        // RGB to YUV conversion using ITU-R BT.601 standard
+        // ITU-R BT.601 標準を使用した RGB から YUV への変換
         let y = (0.299 * r + 0.587 * g + 0.114 * b) as u8;
         let u = ((-0.169 * r - 0.331 * g + 0.500 * b) + 128.0) as u8;
         let v = ((0.500 * r - 0.419 * g - 0.081 * b) + 128.0) as u8;
@@ -103,13 +103,13 @@ impl VideoFrame {
 
         let mut data = Vec::with_capacity(total_size);
 
-        // Fill Y plane
+        // Y プレーンを埋める
         data.resize(y_plane_size, y);
 
-        // Fill U plane
+        // U プレーンを埋める
         data.resize(y_plane_size + u_plane_size, u);
 
-        // Fill V plane
+        // V プレーンを埋める
         data.resize(total_size, v);
 
         Self {

--- a/src/video.rs
+++ b/src/video.rs
@@ -80,6 +80,51 @@ impl VideoFrame {
         }
     }
 
+    pub fn mono_color(rgb: [u8; 3], width: EvenUsize, height: EvenUsize) -> Self {
+        if rgb == [0, 0, 0] {
+            // 典型的なユースケースでは最適化された実装を使う
+            return Self::black(width, height);
+        }
+
+        // Convert RGB to YUV
+        let r = rgb[0] as f32;
+        let g = rgb[1] as f32;
+        let b = rgb[2] as f32;
+
+        // RGB to YUV conversion using ITU-R BT.601 standard
+        let y = (0.299 * r + 0.587 * g + 0.114 * b) as u8;
+        let u = ((-0.169 * r - 0.331 * g + 0.500 * b) + 128.0) as u8;
+        let v = ((0.500 * r - 0.419 * g - 0.081 * b) + 128.0) as u8;
+
+        let y_plane_size = width.get() * height.get();
+        let u_plane_size = (width.get() / 2) * (height.get() / 2);
+        let v_plane_size = u_plane_size;
+        let total_size = y_plane_size + u_plane_size + v_plane_size;
+
+        let mut data = Vec::with_capacity(total_size);
+
+        // Fill Y plane
+        data.resize(y_plane_size, y);
+
+        // Fill U plane
+        data.resize(y_plane_size + u_plane_size, u);
+
+        // Fill V plane
+        data.resize(total_size, v);
+
+        Self {
+            source_id: None,
+            data,
+            format: VideoFormat::I420,
+            keyframe: true,
+            width,
+            height,
+            timestamp: Duration::ZERO,
+            duration: Duration::ZERO,
+            sample_entry: None,
+        }
+    }
+
     pub fn black(width: EvenUsize, height: EvenUsize) -> Self {
         let y_plane_size = width.get() * height.get();
         let u_plane_size = (width.get() / 2) * (height.get() / 2);

--- a/tests/layout_test.rs
+++ b/tests/layout_test.rs
@@ -6,7 +6,7 @@ use std::{
 
 use hisui::{
     layout::{self, AggregatedSourceInfo, AssignedSource, Resolution},
-    layout_region::{assign_sources, decide_grid_dimensions, decide_required_cells, ReuseKind},
+    layout_region::{ReuseKind, assign_sources, decide_grid_dimensions, decide_required_cells},
     metadata::{SourceId, SourceInfo},
 };
 use orfail::OrFail;
@@ -624,10 +624,12 @@ fn source_path_outside_base_dir_error() -> orfail::Result<()> {
     let result =
         layout::resolve_source_paths(&base_path, &[PathBuf::from("../files2/foo-0.json")], &[]);
     assert!(result.is_err());
-    assert!(result
-        .unwrap_err()
-        .to_string()
-        .contains("outside the base dir"));
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("outside the base dir")
+    );
 
     Ok(())
 }
@@ -657,10 +659,12 @@ fn wildcard_excludes_sources_without_media_files() -> orfail::Result<()> {
         &[],
     );
     assert!(result.is_err());
-    assert!(result
-        .unwrap_err()
-        .to_string()
-        .contains("no media file for the source"));
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("no media file for the source")
+    );
 
     Ok(())
 }

--- a/tests/mixer_video_test.rs
+++ b/tests/mixer_video_test.rs
@@ -819,6 +819,8 @@ fn region(region_size: Size, cell_size: Size) -> Region {
         // 以下のフィールドは VideoMixer では使われないので何でもいい
         // (Layout::video_regions の並びが z_pos を反映していることが前提）
         z_pos: 0,
+
+        background_color: [0, 0, 0],
     }
 }
 

--- a/tests/mixer_video_test.rs
+++ b/tests/mixer_video_test.rs
@@ -815,12 +815,11 @@ fn region(region_size: Size, cell_size: Size) -> Region {
         position: PixelPosition::default(),
         top_border_pixels: EvenUsize::default(),
         left_border_pixels: EvenUsize::default(),
+        background_color: [0, 0, 0],
 
         // 以下のフィールドは VideoMixer では使われないので何でもいい
         // (Layout::video_regions の並びが z_pos を反映していることが前提）
         z_pos: 0,
-
-        background_color: [0, 0, 0],
     }
 }
 

--- a/tests/writer_mp4_tests.rs
+++ b/tests/writer_mp4_tests.rs
@@ -223,6 +223,7 @@ fn region(video_sources: &[SourceInfo]) -> Region {
         top_border_pixels: EvenUsize::default(),
         left_border_pixels: EvenUsize::default(),
         z_pos: 0,
+        background_color: [0, 0, 0],
     }
 }
 


### PR DESCRIPTION
レイアウト JSON のリージョン部分に以下のように指定することで、背景色を黒から任意の色に変更できるようにする:
```json
"background_color": [200, 0, 0]
```

この機能はアンドキュメンテッドなものであり、将来的に予告なく削除や仕様変更される可能性がある。