### PR TITLE
MediaProcessor トレイトの導入

### DIFF
--- a/src/composer.rs
+++ b/src/composer.rs
@@ -221,9 +221,14 @@ pub fn create_audio_and_video_sources(
                 openh264_lib: openh264_lib.clone(),
             };
             let decoder = VideoDecoder::new(options);
-            let source_rx =
-                VideoSourceThread::start(error_flag.clone(), source_info, decoder, stats.clone())
-                    .or_fail()?;
+            let source_rx = VideoSourceThread::start(
+                error_flag.clone(),
+                source_info,
+                decoder,
+                &mut stream_id_gen,
+                stats.clone(),
+            )
+            .or_fail()?;
             video_source_rxs.push(source_rx);
         }
     }

--- a/src/composer.rs
+++ b/src/composer.rs
@@ -6,7 +6,7 @@ use shiguredo_openh264::Openh264Library;
 use crate::{
     audio::AudioDataReceiver,
     channel::{self, ErrorFlag},
-    decoder::{VideoDecoder, VideoDecoderOptions},
+    decoder::VideoDecoderOptions,
     encoder::{AudioEncoder, AudioEncoderThread, VideoEncoder, VideoEncoderThread},
     layout::Layout,
     media::MediaStreamIdGenerator,
@@ -220,11 +220,10 @@ pub fn create_audio_and_video_sources(
             let options = VideoDecoderOptions {
                 openh264_lib: openh264_lib.clone(),
             };
-            let decoder = VideoDecoder::new(options);
             let source_rx = VideoSourceThread::start(
                 error_flag.clone(),
                 source_info,
-                decoder,
+                options,
                 &mut stream_id_gen,
                 stats.clone(),
             )

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -185,7 +185,7 @@ impl VideoDecoder {
     }
 
     // TODO: delete
-    pub(crate) fn decode(
+    pub fn decode(
         &mut self,
         frame: VideoFrame,
         stats: &mut VideoDecoderStats,
@@ -194,12 +194,12 @@ impl VideoDecoder {
     }
 
     // TODO: delete
-    pub(crate) fn finish(&mut self) -> orfail::Result<()> {
+    pub fn finish(&mut self) -> orfail::Result<()> {
         self.inner.finish()
     }
 
     // TODO: delete
-    pub(crate) fn next_decoded_frame(&mut self) -> Option<VideoFrame> {
+    pub fn next_decoded_frame(&mut self) -> Option<VideoFrame> {
         self.inner.next_decoded_frame()
     }
 }

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -48,9 +48,7 @@ impl AudioDecoder {
         })
     }
 
-    // TODO: remove
     pub(crate) fn decode(&mut self, data: &AudioData) -> orfail::Result<AudioData> {
-        // TODO: stats handling
         self.inner.decode(data).or_fail()
     }
 

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -79,10 +79,12 @@ impl MediaProcessor for AudioDecoder {
 
         let (decoded, elapsed) = Seconds::try_elapsed(|| self.inner.decode(&data).or_fail())?;
         self.stats.total_audio_data_count.add(1);
-        self.stats.total_processing_seconds.add(elapsed);
         if let Some(id) = &data.source_id {
             self.stats.source_id.set_once(|| id.clone());
         }
+
+        // TODO: プロセッサ実行スレッドの導入タイミングで、時間計測はそっちに移動する
+        self.stats.total_processing_seconds.add(elapsed);
 
         self.decoded.push_back(decoded);
         Ok(())

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -49,7 +49,7 @@ impl AudioDecoder {
     }
 
     // TODO: remove
-    pub fn decode(&mut self, data: &AudioData) -> orfail::Result<AudioData> {
+    pub(crate) fn decode(&mut self, data: &AudioData) -> orfail::Result<AudioData> {
         // TODO: stats handling
         self.inner.decode(data).or_fail()
     }

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -29,13 +29,10 @@ pub struct AudioDecoder {
 }
 
 impl AudioDecoder {
-    pub fn new_opus(/*
-         input_stream_id: MediaStreamId,
+    pub fn new_opus(
+        input_stream_id: MediaStreamId,
         output_stream_id: MediaStreamId,
-*/) -> orfail::Result<Self> {
-        let input_stream_id = MediaStreamId::new(0); // TODO
-        let output_stream_id = MediaStreamId::new(1); // TODO
-
+    ) -> orfail::Result<Self> {
         let stats = AudioDecoderStats::default();
         Ok(Self {
             input_stream_id,

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -56,7 +56,8 @@ impl AudioDecoder {
             sample: Some(MediaSample::audio_data(data)),
         };
         self.process_input(input).or_fail()?;
-        let MediaProcessorOutput::Processed { sample, .. } = self.process_output().or_fail()? else {
+        let MediaProcessorOutput::Processed { sample, .. } = self.process_output().or_fail()?
+        else {
             return Err(orfail::Failure::new("bug"));
         };
         let decoded = sample.expect_audio_data().or_fail()?;
@@ -102,7 +103,7 @@ impl MediaProcessor for AudioDecoder {
     }
 
     fn process_output(&mut self) -> orfail::Result<MediaProcessorOutput> {
-        if let Some(data) = self.decoded.pop_back() {
+        if let Some(data) = self.decoded.pop_front() {
             Ok(MediaProcessorOutput::Processed {
                 stream_id: self.output_stream_id,
                 sample: MediaSample::audio_data(data),
@@ -263,7 +264,7 @@ impl MediaProcessor for VideoDecoder {
     }
 
     fn process_output(&mut self) -> orfail::Result<MediaProcessorOutput> {
-        if let Some(frame) = self.decoded.pop_back() {
+        if let Some(frame) = self.decoded.pop_front() {
             Ok(MediaProcessorOutput::Processed {
                 stream_id: self.output_stream_id,
                 sample: MediaSample::video_frame(frame),

--- a/src/decoder_dav1d.rs
+++ b/src/decoder_dav1d.rs
@@ -23,11 +23,11 @@ impl Dav1dDecoder {
         })
     }
 
-    pub fn decode(&mut self, frame: VideoFrame) -> orfail::Result<()> {
+    pub fn decode(&mut self, frame: &VideoFrame) -> orfail::Result<()> {
         (frame.format == VideoFormat::Av1).or_fail()?;
 
         self.inner.decode(&frame.data).or_fail()?;
-        self.input_queue.push_back(frame);
+        self.input_queue.push_back(frame.to_stripped());
         self.handle_decoded_frames().or_fail()?;
         Ok(())
     }

--- a/src/decoder_libvpx.rs
+++ b/src/decoder_libvpx.rs
@@ -33,11 +33,11 @@ impl LibvpxDecoder {
         })
     }
 
-    pub fn decode(&mut self, frame: VideoFrame) -> orfail::Result<()> {
+    pub fn decode(&mut self, frame: &VideoFrame) -> orfail::Result<()> {
         matches!(frame.format, VideoFormat::Vp8 | VideoFormat::Vp9).or_fail()?;
 
         self.inner.decode(&frame.data).or_fail()?;
-        self.input_queue.push_back(frame);
+        self.input_queue.push_back(frame.to_stripped());
         self.handle_decoded_frames().or_fail()?;
         Ok(())
     }

--- a/src/decoder_openh264.rs
+++ b/src/decoder_openh264.rs
@@ -24,7 +24,7 @@ impl Openh264Decoder {
         })
     }
 
-    pub fn decode(&mut self, frame: VideoFrame) -> orfail::Result<()> {
+    pub fn decode(&mut self, frame: &VideoFrame) -> orfail::Result<()> {
         matches!(frame.format, VideoFormat::H264 | VideoFormat::H264AnnexB).or_fail()?;
 
         if frame.keyframe {
@@ -54,7 +54,7 @@ impl Openh264Decoder {
         } else {
             self.inner.decode(&frame.data).or_fail()?
         };
-        self.input_queue.push_back(frame);
+        self.input_queue.push_back(frame.to_stripped());
 
         let Some(decoded) = decoded else {
             // まだデコーダーのバッファ内にある

--- a/src/decoder_video_toolbox.rs
+++ b/src/decoder_video_toolbox.rs
@@ -90,7 +90,7 @@ impl VideoToolboxDecoder {
         Ok(())
     }
 
-    pub fn decode(&mut self, frame: VideoFrame) -> orfail::Result<()> {
+    pub fn decode(&mut self, frame: &VideoFrame) -> orfail::Result<()> {
         matches!(
             frame.format,
             VideoFormat::H264 | VideoFormat::H264AnnexB | VideoFormat::H265
@@ -116,7 +116,7 @@ impl VideoToolboxDecoder {
         };
 
         self.decoded = Some(VideoFrame::new_i420(
-            frame,
+            frame.to_stripped(),
             EvenUsize::new(decoded.width()).or_fail()?,
             EvenUsize::new(decoded.height()).or_fail()?,
             decoded.y_plane(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ pub mod metadata;
 pub mod mixer_audio;
 pub mod mixer_video;
 pub mod optuna;
+pub mod processor;
 pub mod reader;
 pub mod reader_mp4;
 pub mod reader_webm;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ pub mod layout;
 pub mod layout_encode_params;
 pub mod layout_region;
 pub mod logger;
+pub mod media;
 pub mod metadata;
 pub mod mixer_audio;
 pub mod mixer_video;

--- a/src/media.rs
+++ b/src/media.rs
@@ -45,6 +45,16 @@ impl MediaSample {
         }
     }
 
+    pub fn expect_video_frame(self) -> orfail::Result<Arc<VideoFrame>> {
+        if let Self::Video(frame) = self {
+            Ok(frame)
+        } else {
+            Err(orfail::Failure::new(
+                "expected a video sample, but got an audio sample",
+            ))
+        }
+    }
+
     pub fn audio_data(data: AudioData) -> Self {
         Self::Audio(Arc::new(data))
     }

--- a/src/media.rs
+++ b/src/media.rs
@@ -24,10 +24,9 @@ impl MediaStreamIdGenerator {
 
 #[derive(Debug, Clone)]
 pub enum MediaSample {
-    Audio(AudioData),
-    Video(VideoFrame),
+    Audio(Arc<AudioData>),
+    Video(Arc<VideoFrame>),
 }
 
-pub type SharedMediaSample = Arc<MediaSample>;
-pub type MediaStreamReceiver = Receiver<SharedMediaSample>;
-pub type MediaStreamSyncSender = SyncSender<SharedMediaSample>;
+pub type MediaStreamReceiver = Receiver<MediaSample>;
+pub type MediaStreamSyncSender = SyncSender<MediaSample>;

--- a/src/media.rs
+++ b/src/media.rs
@@ -7,6 +7,21 @@ use crate::video::VideoFrame;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct MediaStreamId(u64);
 
+#[derive(Debug)]
+pub struct MediaStreamIdGenerator(MediaStreamId);
+
+impl MediaStreamIdGenerator {
+    pub fn new() -> Self {
+        Self(MediaStreamId(0))
+    }
+
+    pub fn next_media_stream_id(&mut self) -> MediaStreamId {
+        let id = self.0;
+        self.0.0 += 1;
+        id
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum MediaSample {
     Audio(AudioData),

--- a/src/media.rs
+++ b/src/media.rs
@@ -7,6 +7,12 @@ use crate::video::VideoFrame;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct MediaStreamId(u64);
 
+impl MediaStreamId {
+    pub const fn new(id: u64) -> Self {
+        Self(id)
+    }
+}
+
 #[derive(Debug)]
 pub struct MediaStreamIdGenerator(MediaStreamId);
 
@@ -15,7 +21,7 @@ impl MediaStreamIdGenerator {
         Self(MediaStreamId(0))
     }
 
-    pub fn next_media_stream_id(&mut self) -> MediaStreamId {
+    pub fn next_id(&mut self) -> MediaStreamId {
         let id = self.0;
         self.0.0 += 1;
         id

--- a/src/media.rs
+++ b/src/media.rs
@@ -1,0 +1,18 @@
+use std::sync::Arc;
+use std::sync::mpsc::{Receiver, SyncSender};
+
+use crate::audio::AudioData;
+use crate::video::VideoFrame;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct MediaStreamId(u64);
+
+#[derive(Debug, Clone)]
+pub enum MediaSample {
+    Audio(AudioData),
+    Video(VideoFrame),
+}
+
+pub type SharedMediaSample = Arc<MediaSample>;
+pub type MediaStreamReceiver = Receiver<SharedMediaSample>;
+pub type MediaStreamSyncSender = SyncSender<SharedMediaSample>;

--- a/src/media.rs
+++ b/src/media.rs
@@ -28,5 +28,15 @@ pub enum MediaSample {
     Video(Arc<VideoFrame>),
 }
 
+impl MediaSample {
+    pub fn audio_data(data: AudioData) -> Self {
+        Self::Audio(Arc::new(data))
+    }
+
+    pub fn video_frame(frame: VideoFrame) -> Self {
+        Self::Video(Arc::new(frame))
+    }
+}
+
 pub type MediaStreamReceiver = Receiver<MediaSample>;
 pub type MediaStreamSyncSender = SyncSender<MediaSample>;

--- a/src/media.rs
+++ b/src/media.rs
@@ -35,6 +35,16 @@ pub enum MediaSample {
 }
 
 impl MediaSample {
+    pub fn expect_audio_data(self) -> orfail::Result<Arc<AudioData>> {
+        if let Self::Audio(sample) = self {
+            Ok(sample)
+        } else {
+            Err(orfail::Failure::new(
+                "expected an audio sample, but got a video sample",
+            ))
+        }
+    }
+
     pub fn audio_data(data: AudioData) -> Self {
         Self::Audio(Arc::new(data))
     }

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -5,8 +5,9 @@ use crate::video::VideoFrame;
 
 pub trait MediaProcessor {
     fn spec(&self) -> MediaProcessorSpec;
-    fn process(&mut self, input: MediaProcessorInput) -> orfail::Result<()>;
-    fn poll_output(&mut self) -> orfail::Result<MediaProcessorOutput>;
+
+    fn process_input(&mut self, input: MediaProcessorInput) -> orfail::Result<()>;
+    fn process_output(&mut self) -> orfail::Result<MediaProcessorOutput>;
 
     fn set_error(&self) {
         self.spec().stats.set_error();

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -1,3 +1,4 @@
+use crate::audio::AudioData;
 use crate::media::{MediaSample, MediaStreamId};
 use crate::stats::ProcessorStats;
 
@@ -17,7 +18,7 @@ pub struct MediaProcessorSpec {
 #[derive(Debug)]
 pub struct MediaProcessorInput {
     pub stream_id: MediaStreamId,
-    pub sample: Option<MediaSample>,
+    pub sample: Option<MediaSample>, // None なら EOS を表す
 }
 
 #[derive(Debug)]
@@ -30,4 +31,13 @@ pub enum MediaProcessorOutput {
         awaiting_stream_id: MediaStreamId,
     },
     Finished,
+}
+
+impl MediaProcessorOutput {
+    pub fn audio_data(stream_id: MediaStreamId, data: AudioData) -> Self {
+        Self::Processed {
+            stream_id,
+            sample: MediaSample::audio_data(data),
+        }
+    }
 }

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -1,0 +1,7 @@
+use crate::stats::ProcessorStats;
+
+pub trait MediaProcessor {
+    fn process_input(&mut self);
+    fn generate_output(&mut self);
+    fn stats(&self) -> ProcessorStats;
+}

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -1,4 +1,4 @@
-use crate::media::{MediaStreamId, SharedMediaSample};
+use crate::media::{MediaSample, MediaStreamId};
 use crate::stats::ProcessorStats;
 
 pub trait MediaProcessor {
@@ -17,14 +17,14 @@ pub struct MediaProcessorSpec {
 #[derive(Debug)]
 pub struct MediaProcessorInput {
     pub stream_id: MediaStreamId,
-    pub sample: Option<SharedMediaSample>,
+    pub sample: Option<MediaSample>,
 }
 
 #[derive(Debug)]
 pub enum MediaProcessorOutput {
     Processed {
         stream_id: MediaStreamId,
-        sample: SharedMediaSample,
+        sample: MediaSample,
     },
     Pending {
         awaiting_stream_id: MediaStreamId,

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -4,6 +4,8 @@ use crate::stats::ProcessorStats;
 pub trait MediaProcessor {
     fn process(&mut self, input: MediaProcessorInput) -> orfail::Result<()>;
     fn poll_output(&mut self) -> orfail::Result<MediaProcessorOutput>;
+    fn input_stream_ids(&self) -> Vec<MediaStreamId>;
+    fn output_stream_ids(&self) -> Vec<MediaStreamId>;
     fn stats(&self) -> ProcessorStats;
 }
 

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -2,11 +2,16 @@ use crate::media::{MediaStreamId, SharedMediaSample};
 use crate::stats::ProcessorStats;
 
 pub trait MediaProcessor {
+    fn spec(&self) -> MediaProcessorSpec;
     fn process(&mut self, input: MediaProcessorInput) -> orfail::Result<()>;
     fn poll_output(&mut self) -> orfail::Result<MediaProcessorOutput>;
-    fn input_stream_ids(&self) -> Vec<MediaStreamId>;
-    fn output_stream_ids(&self) -> Vec<MediaStreamId>;
-    fn stats(&self) -> ProcessorStats;
+}
+
+#[derive(Debug)]
+pub struct MediaProcessorSpec {
+    pub input_stream_ids: Vec<MediaStreamId>,
+    pub output_stream_ids: Vec<MediaStreamId>,
+    pub stats: ProcessorStats,
 }
 
 #[derive(Debug)]

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -1,7 +1,26 @@
+use crate::media::{MediaStreamId, SharedMediaSample};
 use crate::stats::ProcessorStats;
 
 pub trait MediaProcessor {
-    fn process_input(&mut self);
-    fn generate_output(&mut self);
+    fn process(&mut self, input: MediaProcessorInput) -> orfail::Result<()>;
+    fn poll_output(&mut self) -> orfail::Result<MediaProcessorOutput>;
     fn stats(&self) -> ProcessorStats;
+}
+
+#[derive(Debug)]
+pub struct MediaProcessorInput {
+    pub stream_id: MediaStreamId,
+    pub sample: Option<SharedMediaSample>,
+}
+
+#[derive(Debug)]
+pub enum MediaProcessorOutput {
+    Processed {
+        stream_id: MediaStreamId,
+        sample: SharedMediaSample,
+    },
+    Pending {
+        awaiting_stream_id: MediaStreamId,
+    },
+    Finished,
 }

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -7,6 +7,10 @@ pub trait MediaProcessor {
     fn spec(&self) -> MediaProcessorSpec;
     fn process(&mut self, input: MediaProcessorInput) -> orfail::Result<()>;
     fn poll_output(&mut self) -> orfail::Result<MediaProcessorOutput>;
+
+    fn set_error(&self) {
+        self.spec().stats.set_error();
+    }
 }
 
 #[derive(Debug)]

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -1,6 +1,7 @@
 use crate::audio::AudioData;
 use crate::media::{MediaSample, MediaStreamId};
 use crate::stats::ProcessorStats;
+use crate::video::VideoFrame;
 
 pub trait MediaProcessor {
     fn spec(&self) -> MediaProcessorSpec;
@@ -38,6 +39,13 @@ impl MediaProcessorOutput {
         Self::Processed {
             stream_id,
             sample: MediaSample::audio_data(data),
+        }
+    }
+
+    pub fn video_frame(stream_id: MediaStreamId, frame: VideoFrame) -> Self {
+        Self::Processed {
+            stream_id,
+            sample: MediaSample::video_frame(frame),
         }
     }
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -78,7 +78,7 @@ impl AudioReaderInner {
     fn stats(&self) -> ProcessorStats {
         match self {
             Self::Mp4(r) => ProcessorStats::Mp4AudioReader(r.stats().clone()),
-            Self::Webm(r) => r.stats(),
+            Self::Webm(r) => ProcessorStats::WebmAudioReader(r.stats().clone()),
         }
     }
 }
@@ -154,7 +154,7 @@ impl VideoReaderInner {
     fn stats(&self) -> ProcessorStats {
         match self {
             Self::Mp4(r) => ProcessorStats::Mp4VideoReader(r.stats().clone()),
-            Self::Webm(r) => r.stats(),
+            Self::Webm(r) => ProcessorStats::WebmVideoReader(r.stats().clone()),
         }
     }
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -8,6 +8,7 @@ use crate::{
     video::VideoFrame,
 };
 
+// TODO: 最終的にはこの enum はなくして直接 Processor に追加する
 #[derive(Debug)]
 pub enum AudioReader {
     Mp4(Mp4AudioReader),
@@ -23,7 +24,10 @@ impl AudioReader {
     }
 
     pub fn output_stream_id(&self) -> MediaStreamId {
-        todo!()
+        match self {
+            AudioReader::Mp4(r) => r.output_stream_id(),
+            AudioReader::Webm(r) => r.output_stream_id(),
+        }
     }
 }
 
@@ -65,6 +69,7 @@ impl MediaProcessor for AudioReader {
     }
 }
 
+// TODO: 最終的にはこの enum はなくして直接 Processor に追加する
 #[derive(Debug)]
 #[expect(clippy::large_enum_variant)]
 pub enum VideoReader {

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -78,7 +78,7 @@ enum AudioReaderInner {
 impl AudioReaderInner {
     fn stats(&self) -> ProcessorStats {
         match self {
-            Self::Mp4(r) => r.stats(),
+            Self::Mp4(r) => ProcessorStats::Mp4AudioReader(r.stats().clone()),
             Self::Webm(r) => r.stats(),
         }
     }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -50,13 +50,13 @@ impl MediaProcessor for AudioReader {
         }
     }
 
-    fn process(&mut self, _input: MediaProcessorInput) -> orfail::Result<()> {
+    fn process_input(&mut self, _input: MediaProcessorInput) -> orfail::Result<()> {
         Err(orfail::Failure::new(
             "BUG: reader does not require any input streams",
         ))
     }
 
-    fn poll_output(&mut self) -> orfail::Result<MediaProcessorOutput> {
+    fn process_output(&mut self) -> orfail::Result<MediaProcessorOutput> {
         match self.next() {
             None => Ok(MediaProcessorOutput::Finished),
             Some(Err(e)) => Err(e),
@@ -125,13 +125,13 @@ impl MediaProcessor for VideoReader {
         }
     }
 
-    fn process(&mut self, _input: MediaProcessorInput) -> orfail::Result<()> {
+    fn process_input(&mut self, _input: MediaProcessorInput) -> orfail::Result<()> {
         Err(orfail::Failure::new(
             "BUG: reader does not require any input streams",
         ))
     }
 
-    fn poll_output(&mut self) -> orfail::Result<MediaProcessorOutput> {
+    fn process_output(&mut self) -> orfail::Result<MediaProcessorOutput> {
         match self.next() {
             None => Ok(MediaProcessorOutput::Finished),
             Some(Err(e)) => Err(e),

--- a/src/reader_mp4.rs
+++ b/src/reader_mp4.rs
@@ -231,7 +231,7 @@ impl Iterator for Mp4VideoReaderInner {
     type Item = orfail::Result<VideoFrame>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        // TODO: refactor
+        // TODO: プロセッサ実行スレッドの導入タイミングで、時間計測はそっちに移動する
         let (result, elapsed) = Seconds::elapsed(|| self.next_video_frame());
         self.stats.total_processing_seconds.add(elapsed);
         if matches!(result, Some(Err(_))) {
@@ -386,6 +386,7 @@ impl Iterator for Mp4AudioReaderInner {
     type Item = orfail::Result<AudioData>;
 
     fn next(&mut self) -> Option<Self::Item> {
+        // TODO: プロセッサ実行スレッドの導入タイミングで、時間計測はそっちに移動する
         let (result, elapsed) = Seconds::elapsed(|| self.next_audio_data());
         self.stats.total_processing_seconds.add(elapsed);
         if matches!(result, Some(Err(_))) {

--- a/src/reader_mp4.rs
+++ b/src/reader_mp4.rs
@@ -19,7 +19,7 @@ use crate::{
     metadata::SourceId,
     stats::{
         Mp4AudioReaderStats, Mp4VideoReaderStats, ProcessorStats, Seconds, SharedAtomicSeconds,
-        SharedOption, VideoResolution,
+        VideoResolution,
     },
     types::{CodecName, EvenUsize},
     video::{VideoFormat, VideoFrame},
@@ -231,6 +231,7 @@ impl Iterator for Mp4VideoReaderInner {
     type Item = orfail::Result<VideoFrame>;
 
     fn next(&mut self) -> Option<Self::Item> {
+        // TODO: refactor
         let (result, elapsed) = Seconds::elapsed(|| self.next_video_frame());
         self.stats.total_processing_seconds.add(elapsed);
         if matches!(result, Some(Err(_))) {
@@ -244,33 +245,21 @@ impl Iterator for Mp4VideoReaderInner {
 pub struct Mp4AudioReader {
     // 音声トラックが存在しない場合は None になる
     inner: Option<Mp4AudioReaderInner>,
-
-    // 音声トラックが存在しない時の統計値
-    default_stats: Mp4AudioReaderStats,
+    stats: Mp4AudioReaderStats,
 }
 
 impl Mp4AudioReader {
     pub fn new<P: AsRef<Path>>(source_id: SourceId, path: P) -> orfail::Result<Self> {
-        let default_stats = Mp4AudioReaderStats {
+        let stats = Mp4AudioReaderStats {
             input_file: path.as_ref().to_path_buf(),
             ..Default::default()
         };
-
-        let inner = Mp4AudioReaderInner::new(source_id, path).or_fail()?;
-
-        Ok(Self {
-            inner,
-            default_stats,
-        })
+        let inner = Mp4AudioReaderInner::new(source_id, path, stats.clone()).or_fail()?;
+        Ok(Self { inner, stats })
     }
 
-    pub fn stats(&self) -> ProcessorStats {
-        ProcessorStats::Mp4AudioReader(
-            self.inner
-                .as_ref()
-                .map_or(&self.default_stats, |x| &x.stats)
-                .clone(),
-        )
+    pub fn stats(&self) -> &Mp4AudioReaderStats {
+        &self.stats
     }
 }
 
@@ -293,7 +282,11 @@ pub struct Mp4AudioReaderInner {
 }
 
 impl Mp4AudioReaderInner {
-    fn new<P: AsRef<Path>>(source_id: SourceId, path: P) -> orfail::Result<Option<Self>> {
+    fn new<P: AsRef<Path>>(
+        source_id: SourceId,
+        path: P,
+        stats: Mp4AudioReaderStats,
+    ) -> orfail::Result<Option<Self>> {
         let start_time = Instant::now();
         let file = File::open(&path)
             .or_fail_with(|e| format!("Cannot open file {}: {e}", path.as_ref().display()))?;
@@ -305,12 +298,10 @@ impl Mp4AudioReaderInner {
 
         file.seek(SeekFrom::Start(0)).or_fail()?;
 
-        let stats = Mp4AudioReaderStats {
-            input_file: path.as_ref().canonicalize().or_fail()?,
-            codec: SharedOption::new(Some(CodecName::Opus)),
-            total_processing_seconds: SharedAtomicSeconds::new(Seconds::new(start_time.elapsed())),
-            ..Default::default()
-        };
+        stats.codec.set(CodecName::Opus);
+        stats
+            .total_processing_seconds
+            .add(Seconds::new(start_time.elapsed()));
 
         Ok(Some(Self {
             source_id,

--- a/src/reader_mp4.rs
+++ b/src/reader_mp4.rs
@@ -242,8 +242,6 @@ impl Iterator for Mp4VideoReaderInner {
 
 #[derive(Debug)]
 pub struct Mp4AudioReader {
-    output_stream_id: MediaStreamId,
-
     // 音声トラックが存在しない場合は None になる
     inner: Option<Mp4AudioReaderInner>,
 
@@ -252,11 +250,7 @@ pub struct Mp4AudioReader {
 }
 
 impl Mp4AudioReader {
-    pub fn new<P: AsRef<Path>>(
-        source_id: SourceId,
-        output_stream_id: MediaStreamId,
-        path: P,
-    ) -> orfail::Result<Self> {
+    pub fn new<P: AsRef<Path>>(source_id: SourceId, path: P) -> orfail::Result<Self> {
         let default_stats = Mp4AudioReaderStats {
             input_file: path.as_ref().to_path_buf(),
             ..Default::default()
@@ -265,14 +259,9 @@ impl Mp4AudioReader {
         let inner = Mp4AudioReaderInner::new(source_id, path).or_fail()?;
 
         Ok(Self {
-            output_stream_id,
             inner,
             default_stats,
         })
-    }
-
-    pub fn output_stream_id(&self) -> MediaStreamId {
-        self.output_stream_id
     }
 
     pub fn stats(&self) -> ProcessorStats {

--- a/src/reader_mp4.rs
+++ b/src/reader_mp4.rs
@@ -15,6 +15,7 @@ use shiguredo_mp4::{
 
 use crate::{
     audio::{AudioData, AudioFormat},
+    media::MediaStreamId,
     metadata::SourceId,
     stats::{
         Mp4AudioReaderStats, Mp4VideoReaderStats, ProcessorStats, Seconds, SharedAtomicSeconds,
@@ -230,6 +231,8 @@ impl Iterator for Mp4VideoReaderInner {
 
 #[derive(Debug)]
 pub struct Mp4AudioReader {
+    output_stream_id: MediaStreamId,
+
     // 音声トラックが存在しない場合は None になる
     inner: Option<Mp4AudioReaderInner>,
 
@@ -238,7 +241,11 @@ pub struct Mp4AudioReader {
 }
 
 impl Mp4AudioReader {
-    pub fn new<P: AsRef<Path>>(source_id: SourceId, path: P) -> orfail::Result<Self> {
+    pub fn new<P: AsRef<Path>>(
+        source_id: SourceId,
+        output_stream_id: MediaStreamId,
+        path: P,
+    ) -> orfail::Result<Self> {
         let default_stats = Mp4AudioReaderStats {
             input_file: path.as_ref().to_path_buf(),
             ..Default::default()
@@ -247,9 +254,14 @@ impl Mp4AudioReader {
         let inner = Mp4AudioReaderInner::new(source_id, path).or_fail()?;
 
         Ok(Self {
+            output_stream_id,
             inner,
             default_stats,
         })
+    }
+
+    pub fn output_stream_id(&self) -> MediaStreamId {
+        self.output_stream_id
     }
 
     pub fn stats(&self) -> ProcessorStats {

--- a/src/reader_mp4.rs
+++ b/src/reader_mp4.rs
@@ -27,6 +27,8 @@ use crate::{
 
 #[derive(Debug)]
 pub struct Mp4VideoReader {
+    output_stream_id: MediaStreamId,
+
     // ビデオトラックが存在しない場合は None になる
     inner: Option<Mp4VideoReaderInner>,
 
@@ -35,7 +37,11 @@ pub struct Mp4VideoReader {
 }
 
 impl Mp4VideoReader {
-    pub fn new<P: AsRef<Path>>(source_id: SourceId, path: P) -> orfail::Result<Self> {
+    pub fn new<P: AsRef<Path>>(
+        source_id: SourceId,
+        output_stream_id: MediaStreamId,
+        path: P,
+    ) -> orfail::Result<Self> {
         let default_stats = Mp4VideoReaderStats {
             input_file: path.as_ref().canonicalize().or_fail_with(|e| {
                 format!(
@@ -49,9 +55,14 @@ impl Mp4VideoReader {
         let inner = Mp4VideoReaderInner::new(source_id, path).or_fail()?;
 
         Ok(Self {
+            output_stream_id,
             inner,
             default_stats,
         })
+    }
+
+    pub fn output_stream_id(&self) -> MediaStreamId {
+        self.output_stream_id
     }
 
     pub fn stats(&self) -> ProcessorStats {

--- a/src/reader_webm.rs
+++ b/src/reader_webm.rs
@@ -9,9 +9,7 @@ use orfail::OrFail;
 use crate::{
     audio::{AudioData, AudioFormat, SAMPLE_RATE},
     metadata::SourceId,
-    stats::{
-        ProcessorStats, Seconds, SharedAtomicSeconds, WebmAudioReaderStats, WebmVideoReaderStats,
-    },
+    stats::{Seconds, SharedAtomicSeconds, WebmAudioReaderStats, WebmVideoReaderStats},
     types::{CodecName, EvenUsize},
     video::{VideoFormat, VideoFrame},
 };
@@ -369,8 +367,8 @@ impl WebmAudioReader {
         })
     }
 
-    pub fn stats(&self) -> ProcessorStats {
-        ProcessorStats::WebmAudioReader(self.stats.clone())
+    pub fn stats(&self) -> &WebmAudioReaderStats {
+        &self.stats
     }
 
     fn read_simple_block(&mut self) -> orfail::Result<Option<AudioData>> {
@@ -515,8 +513,8 @@ impl WebmVideoReader {
         })
     }
 
-    pub fn stats(&self) -> ProcessorStats {
-        ProcessorStats::WebmVideoReader(self.stats.clone())
+    pub fn stats(&self) -> &WebmVideoReaderStats {
+        &self.stats
     }
 
     fn read_video_frame(&mut self) -> orfail::Result<Option<VideoFrame>> {

--- a/src/reader_webm.rs
+++ b/src/reader_webm.rs
@@ -460,6 +460,7 @@ impl Iterator for WebmAudioReader {
     type Item = orfail::Result<AudioData>;
 
     fn next(&mut self) -> Option<Self::Item> {
+        // TODO: プロセッサ実行スレッドの導入タイミングで、時間計測はそっちに移動する
         let (result, elapsed) = Seconds::elapsed(|| self.read_audio_data().or_fail());
         self.stats.total_processing_seconds.add(elapsed);
         if result.is_err() {
@@ -622,6 +623,7 @@ impl Iterator for WebmVideoReader {
     type Item = orfail::Result<VideoFrame>;
 
     fn next(&mut self) -> Option<Self::Item> {
+        // TODO: プロセッサ実行スレッドの導入タイミングで、時間計測はそっちに移動する
         let (result, elapsed) = Seconds::elapsed(|| self.read_video_frame().or_fail());
         self.stats.total_processing_seconds.add(elapsed);
         if result.is_err() {

--- a/src/reader_webm.rs
+++ b/src/reader_webm.rs
@@ -8,7 +8,6 @@ use orfail::OrFail;
 
 use crate::{
     audio::{AudioData, AudioFormat, SAMPLE_RATE},
-    media::MediaStreamId,
     metadata::SourceId,
     stats::{
         ProcessorStats, Seconds, SharedAtomicSeconds, WebmAudioReaderStats, WebmVideoReaderStats,
@@ -473,7 +472,6 @@ impl Iterator for WebmAudioReader {
 #[derive(Debug)]
 pub struct WebmVideoReader {
     source_id: SourceId,
-    output_stream_id: MediaStreamId,
     header: VideoTrackHeader,
     reader: ElementReader<std::io::Take<BufReader<std::fs::File>>>,
     cluster_timestamp: Duration,
@@ -483,11 +481,7 @@ pub struct WebmVideoReader {
 }
 
 impl WebmVideoReader {
-    pub fn new<P: AsRef<Path>>(
-        source_id: SourceId,
-        output_stream_id: MediaStreamId,
-        path: P,
-    ) -> orfail::Result<Self> {
+    pub fn new<P: AsRef<Path>>(source_id: SourceId, path: P) -> orfail::Result<Self> {
         let start_time = Instant::now();
         let file = std::fs::File::open(&path).or_fail()?;
         let mut reader = ElementReader::new(BufReader::new(file));
@@ -511,7 +505,6 @@ impl WebmVideoReader {
             ..Default::default()
         };
         Ok(Self {
-            output_stream_id,
             source_id,
             header,
             reader,
@@ -520,10 +513,6 @@ impl WebmVideoReader {
             prev_video_frame: None,
             stats,
         })
-    }
-
-    pub fn output_stream_id(&self) -> MediaStreamId {
-        self.output_stream_id
     }
 
     pub fn stats(&self) -> ProcessorStats {

--- a/src/reader_webm.rs
+++ b/src/reader_webm.rs
@@ -482,6 +482,7 @@ impl Iterator for WebmAudioReader {
 #[derive(Debug)]
 pub struct WebmVideoReader {
     source_id: SourceId,
+    output_stream_id: MediaStreamId,
     header: VideoTrackHeader,
     reader: ElementReader<std::io::Take<BufReader<std::fs::File>>>,
     cluster_timestamp: Duration,
@@ -491,7 +492,11 @@ pub struct WebmVideoReader {
 }
 
 impl WebmVideoReader {
-    pub fn new<P: AsRef<Path>>(source_id: SourceId, path: P) -> orfail::Result<Self> {
+    pub fn new<P: AsRef<Path>>(
+        source_id: SourceId,
+        output_stream_id: MediaStreamId,
+        path: P,
+    ) -> orfail::Result<Self> {
         let start_time = Instant::now();
         let file = std::fs::File::open(&path).or_fail()?;
         let mut reader = ElementReader::new(BufReader::new(file));
@@ -515,6 +520,7 @@ impl WebmVideoReader {
             ..Default::default()
         };
         Ok(Self {
+            output_stream_id,
             source_id,
             header,
             reader,
@@ -523,6 +529,10 @@ impl WebmVideoReader {
             prev_video_frame: None,
             stats,
         })
+    }
+
+    pub fn output_stream_id(&self) -> MediaStreamId {
+        self.output_stream_id
     }
 
     pub fn stats(&self) -> ProcessorStats {

--- a/src/reader_webm.rs
+++ b/src/reader_webm.rs
@@ -329,7 +329,6 @@ impl VideoTrackHeader {
 #[derive(Debug)]
 pub struct WebmAudioReader {
     source_id: SourceId,
-    output_stream_id: MediaStreamId,
     reader: ElementReader<std::io::Take<BufReader<std::fs::File>>>,
     cluster_timestamp: Duration,
     last_duration: Duration,
@@ -338,11 +337,7 @@ pub struct WebmAudioReader {
 }
 
 impl WebmAudioReader {
-    pub fn new<P: AsRef<Path>>(
-        source_id: SourceId,
-        output_stream_id: MediaStreamId,
-        path: P,
-    ) -> orfail::Result<Self> {
+    pub fn new<P: AsRef<Path>>(source_id: SourceId, path: P) -> orfail::Result<Self> {
         let start_time = Instant::now();
         let file = std::fs::File::open(&path)
             .or_fail_with(|e| format!("failed to open {}: {e}", path.as_ref().display()))?;
@@ -367,17 +362,12 @@ impl WebmAudioReader {
         };
         Ok(Self {
             source_id,
-            output_stream_id,
             reader,
             cluster_timestamp: Duration::ZERO,
             last_duration: Duration::ZERO,
             prev_audio_data: None,
             stats,
         })
-    }
-
-    pub fn output_stream_id(&self) -> MediaStreamId {
-        self.output_stream_id
     }
 
     pub fn stats(&self) -> ProcessorStats {

--- a/src/source.rs
+++ b/src/source.rs
@@ -5,7 +5,7 @@ use orfail::OrFail;
 use crate::{
     audio::AudioData,
     channel::{self, ErrorFlag},
-    decoder::{AudioDecoder, VideoDecoder},
+    decoder::{AudioDecoder, VideoDecoder, VideoDecoderOptions},
     layout::AggregatedSourceInfo,
     media::{MediaStreamId, MediaStreamIdGenerator},
     metadata::{ContainerFormat, SourceId},
@@ -123,13 +123,16 @@ impl VideoSourceThread {
     pub fn start(
         error_flag: ErrorFlag,
         source_info: &AggregatedSourceInfo,
-        decoder: VideoDecoder,
+        options: VideoDecoderOptions,
         stream_id_gen: &mut MediaStreamIdGenerator,
         stats: SharedStats,
     ) -> orfail::Result<channel::Receiver<VideoFrame>> {
         let start_timestamp = source_info.start_timestamp;
 
         let read_stream_id = stream_id_gen.next_id();
+        let decoded_stream_id = stream_id_gen.next_id();
+        let decoder = VideoDecoder::new(read_stream_id, decoded_stream_id, options);
+
         let mut media_file_queue = MediaFileQueue::new(source_info);
         let reader = media_file_queue
             .next_video_reader(read_stream_id)

--- a/src/source.rs
+++ b/src/source.rs
@@ -93,7 +93,7 @@ impl AudioSourceThread {
                     Seconds::try_elapsed(|| self.decoder.decode(&data).or_fail())?;
                 self.decoder_stats.total_audio_data_count.add(1);
                 self.decoder_stats.total_processing_seconds.add(elapsed);
-                self.decoder_stats.source_id = data.source_id;
+                // TODO: self.decoder_stats.source_id = data.source_id;
                 if !self.tx.send(decoded) {
                     // 受信側がすでに閉じている場合にはこれ以上処理しても仕方がないので終了する
                     log::info!("receiver of audio source has been closed");

--- a/src/source.rs
+++ b/src/source.rs
@@ -153,7 +153,7 @@ impl VideoSourceThread {
                 log::error!("failed to load video source: {e}");
             }
             stats.with_lock(|stats| {
-                stats.processors.push(this.reader.stats());
+                stats.processors.push(this.reader.spec().stats);
                 stats
                     .processors
                     .push(ProcessorStats::VideoDecoder(this.decoder_stats));
@@ -173,7 +173,7 @@ impl VideoSourceThread {
             {
                 // 次の分割録画ファイルがある
                 stats.with_lock(|stats| {
-                    stats.processors.push(self.reader.stats());
+                    stats.processors.push(self.reader.spec().stats);
                 });
                 self.reader = reader;
 
@@ -304,13 +304,14 @@ impl MediaFileQueue {
         };
 
         let reader = if self.format == ContainerFormat::Webm {
-            VideoReader::Webm(
-                WebmVideoReader::new(self.source_id.clone(), read_stream_id, info.path)
-                    .or_fail()?,
+            VideoReader::new_webm(
+                read_stream_id,
+                WebmVideoReader::new(self.source_id.clone(), info.path).or_fail()?,
             )
         } else {
-            VideoReader::Mp4(
-                Mp4VideoReader::new(self.source_id.clone(), read_stream_id, info.path).or_fail()?,
+            VideoReader::new_mp4(
+                read_stream_id,
+                Mp4VideoReader::new(self.source_id.clone(), info.path).or_fail()?,
             )
         };
         Ok(Some(reader))

--- a/src/source.rs
+++ b/src/source.rs
@@ -80,7 +80,7 @@ impl AudioSourceThread {
                 data.timestamp += self.start_timestamp;
                 next_timestamp = data.timestamp + data.duration;
 
-                let decoded = self.decoder.decode(&data).or_fail()?;
+                let decoded = self.decoder.decode(data).or_fail()?;
                 if !self.tx.send(decoded) {
                     // 受信側がすでに閉じている場合にはこれ以上処理しても仕方がないので終了する
                     log::info!("receiver of audio source has been closed");

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -161,6 +161,24 @@ pub enum ProcessorStats {
     Mp4Writer(Mp4WriterStats),
 }
 
+impl ProcessorStats {
+    pub fn set_error(&self) {
+        match self {
+            ProcessorStats::Mp4AudioReader(stats) => stats.error.set(true),
+            ProcessorStats::Mp4VideoReader(stats) => stats.error.set(true),
+            ProcessorStats::WebmAudioReader(stats) => stats.error.set(true),
+            ProcessorStats::WebmVideoReader(stats) => stats.error.set(true),
+            ProcessorStats::AudioDecoder(stats) => stats.error.set(true),
+            ProcessorStats::VideoDecoder(stats) => stats.error.set(true),
+            ProcessorStats::AudioMixer(stats) => stats.error.set(true),
+            ProcessorStats::VideoMixer(stats) => stats.error.set(true),
+            ProcessorStats::AudioEncoder(stats) => stats.error.set(true),
+            ProcessorStats::VideoEncoder(stats) => stats.error.set(true),
+            ProcessorStats::Mp4Writer(stats) => stats.error.set(true),
+        }
+    }
+}
+
 impl nojson::DisplayJson for ProcessorStats {
     fn fmt(&self, f: &mut nojson::JsonFormatter<'_, '_>) -> std::fmt::Result {
         match self {
@@ -891,6 +909,9 @@ pub struct Mp4WriterStats {
 
     /// MP4 出力処理部分に掛かった時間
     pub total_processing_seconds: SharedAtomicSeconds,
+
+    /// エラーで中断したかどうか
+    pub error: SharedAtomicFlag,
 }
 
 impl nojson::DisplayJson for Mp4WriterStats {
@@ -937,6 +958,7 @@ impl nojson::DisplayJson for Mp4WriterStats {
                 "total_processing_seconds",
                 self.total_processing_seconds.get_seconds(),
             )?;
+            f.member("error", self.error.get())?;
             Ok(())
         })
     }

--- a/src/subcommand_inspect.rs
+++ b/src/subcommand_inspect.rs
@@ -6,7 +6,6 @@ use crate::{
     metadata::{ContainerFormat, SourceId},
     reader_mp4::{Mp4AudioReader, Mp4VideoReader},
     reader_webm::{WebmAudioReader, WebmVideoReader},
-    stats::VideoDecoderStats,
     types::CodecName,
     video::{VideoFormat, VideoFrame},
     video_h264::H264AnnexBNalUnits,
@@ -111,7 +110,6 @@ pub fn run(mut args: noargs::RawArgs) -> noargs::Result<()> {
     let mut video_codec = None;
     let mut video_samples = Vec::new();
     let mut video_decoder = None;
-    let mut video_decoder_stats = VideoDecoderStats::default();
     let mut decoded_count = 0;
     for sample in video_reader {
         let sample = sample.or_fail()?;
@@ -145,7 +143,7 @@ pub fn run(mut args: noargs::RawArgs) -> noargs::Result<()> {
         });
 
         if let Some(decoder) = &mut video_decoder {
-            decoder.decode(sample, &mut video_decoder_stats).or_fail()?;
+            decoder.decode(sample).or_fail()?;
             while let Some(decoded) = decoder.next_decoded_frame() {
                 video_samples[decoded_count].update(&decoded);
                 decoded_count += 1;

--- a/src/subcommand_inspect.rs
+++ b/src/subcommand_inspect.rs
@@ -54,6 +54,7 @@ pub fn run(mut args: noargs::RawArgs) -> noargs::Result<()> {
     let dummy_source_id = SourceId::new("inspect"); // 使われないのでなんでもいい
 
     let audio_stream_id = MediaStreamId::new(0);
+    let video_stream_id = MediaStreamId::new(1);
     let (audio_reader, video_reader): (Box<dyn Iterator<Item = _>>, Box<dyn Iterator<Item = _>>) =
         match format {
             ContainerFormat::Webm => {
@@ -66,7 +67,12 @@ pub fn run(mut args: noargs::RawArgs) -> noargs::Result<()> {
                     .or_fail()?,
                 );
                 let video = Box::new(
-                    WebmVideoReader::new(dummy_source_id.clone(), &input_file_path).or_fail()?,
+                    WebmVideoReader::new(
+                        dummy_source_id.clone(),
+                        video_stream_id,
+                        &input_file_path,
+                    )
+                    .or_fail()?,
                 );
                 (audio, video)
             }
@@ -76,7 +82,8 @@ pub fn run(mut args: noargs::RawArgs) -> noargs::Result<()> {
                         .or_fail()?,
                 );
                 let video = Box::new(
-                    Mp4VideoReader::new(dummy_source_id.clone(), &input_file_path).or_fail()?,
+                    Mp4VideoReader::new(dummy_source_id.clone(), video_stream_id, &input_file_path)
+                        .or_fail()?,
                 );
                 (audio, video)
             }

--- a/src/subcommand_inspect.rs
+++ b/src/subcommand_inspect.rs
@@ -59,12 +59,7 @@ pub fn run(mut args: noargs::RawArgs) -> noargs::Result<()> {
         match format {
             ContainerFormat::Webm => {
                 let audio = Box::new(
-                    WebmAudioReader::new(
-                        dummy_source_id.clone(),
-                        audio_stream_id,
-                        &input_file_path,
-                    )
-                    .or_fail()?,
+                    WebmAudioReader::new(dummy_source_id.clone(), &input_file_path).or_fail()?,
                 );
                 let video = Box::new(
                     WebmVideoReader::new(
@@ -78,8 +73,7 @@ pub fn run(mut args: noargs::RawArgs) -> noargs::Result<()> {
             }
             ContainerFormat::Mp4 => {
                 let audio = Box::new(
-                    Mp4AudioReader::new(dummy_source_id.clone(), audio_stream_id, &input_file_path)
-                        .or_fail()?,
+                    Mp4AudioReader::new(dummy_source_id.clone(), &input_file_path).or_fail()?,
                 );
                 let video = Box::new(
                     Mp4VideoReader::new(dummy_source_id.clone(), video_stream_id, &input_file_path)

--- a/src/subcommand_inspect.rs
+++ b/src/subcommand_inspect.rs
@@ -54,7 +54,7 @@ pub fn run(mut args: noargs::RawArgs) -> noargs::Result<()> {
     let dummy_source_id = SourceId::new("inspect"); // 使われないのでなんでもいい
 
     let audio_stream_id = MediaStreamId::new(0);
-    let _video_stream_id = MediaStreamId::new(1);
+    let video_stream_id = MediaStreamId::new(1);
     let (audio_reader, video_reader): (Box<dyn Iterator<Item = _>>, Box<dyn Iterator<Item = _>>) =
         match format {
             ContainerFormat::Webm => {
@@ -107,6 +107,7 @@ pub fn run(mut args: noargs::RawArgs) -> noargs::Result<()> {
         audio_samples.push(info);
     }
 
+    let decoded_video_stream_id = MediaStreamId::new(3);
     let mut video_codec = None;
     let mut video_samples = Vec::new();
     let mut video_decoder = None;
@@ -124,7 +125,11 @@ pub fn run(mut args: noargs::RawArgs) -> noargs::Result<()> {
                         .transpose()
                         .or_fail()?,
                 };
-                video_decoder = Some(VideoDecoder::new(options));
+                video_decoder = Some(VideoDecoder::new(
+                    video_stream_id,
+                    decoded_video_stream_id,
+                    options,
+                ));
             }
         }
 

--- a/src/subcommand_inspect.rs
+++ b/src/subcommand_inspect.rs
@@ -99,7 +99,7 @@ pub fn run(mut args: noargs::RawArgs) -> noargs::Result<()> {
         };
 
         if let Some(decoder) = &mut audio_decoder {
-            let decoded = decoder.decode(&sample).or_fail()?;
+            let decoded = decoder.decode(sample).or_fail()?;
             info.decoded_data_size = Some(decoded.data.len());
         }
 

--- a/src/subcommand_inspect.rs
+++ b/src/subcommand_inspect.rs
@@ -89,6 +89,7 @@ pub fn run(mut args: noargs::RawArgs) -> noargs::Result<()> {
             }
         };
 
+    let decoded_audio_stream_id = MediaStreamId::new(2);
     let mut audio_codec = None;
     let mut audio_samples = Vec::new();
     let mut audio_decoder = None;
@@ -97,7 +98,9 @@ pub fn run(mut args: noargs::RawArgs) -> noargs::Result<()> {
         if audio_codec.is_none() {
             audio_codec = sample.format.codec_name();
             if decode {
-                audio_decoder = Some(AudioDecoder::new_opus().or_fail()?);
+                audio_decoder = Some(
+                    AudioDecoder::new_opus(audio_stream_id, decoded_audio_stream_id).or_fail()?,
+                );
             }
         }
 

--- a/src/subcommand_inspect.rs
+++ b/src/subcommand_inspect.rs
@@ -54,7 +54,7 @@ pub fn run(mut args: noargs::RawArgs) -> noargs::Result<()> {
     let dummy_source_id = SourceId::new("inspect"); // 使われないのでなんでもいい
 
     let audio_stream_id = MediaStreamId::new(0);
-    let video_stream_id = MediaStreamId::new(1);
+    let _video_stream_id = MediaStreamId::new(1);
     let (audio_reader, video_reader): (Box<dyn Iterator<Item = _>>, Box<dyn Iterator<Item = _>>) =
         match format {
             ContainerFormat::Webm => {
@@ -62,12 +62,7 @@ pub fn run(mut args: noargs::RawArgs) -> noargs::Result<()> {
                     WebmAudioReader::new(dummy_source_id.clone(), &input_file_path).or_fail()?,
                 );
                 let video = Box::new(
-                    WebmVideoReader::new(
-                        dummy_source_id.clone(),
-                        video_stream_id,
-                        &input_file_path,
-                    )
-                    .or_fail()?,
+                    WebmVideoReader::new(dummy_source_id.clone(), &input_file_path).or_fail()?,
                 );
                 (audio, video)
             }
@@ -76,8 +71,7 @@ pub fn run(mut args: noargs::RawArgs) -> noargs::Result<()> {
                     Mp4AudioReader::new(dummy_source_id.clone(), &input_file_path).or_fail()?,
                 );
                 let video = Box::new(
-                    Mp4VideoReader::new(dummy_source_id.clone(), video_stream_id, &input_file_path)
-                        .or_fail()?,
+                    Mp4VideoReader::new(dummy_source_id.clone(), &input_file_path).or_fail()?,
                 );
                 (audio, video)
             }

--- a/src/subcommand_inspect.rs
+++ b/src/subcommand_inspect.rs
@@ -2,6 +2,7 @@ use std::{path::PathBuf, time::Duration};
 
 use crate::{
     decoder::{AudioDecoder, VideoDecoder, VideoDecoderOptions},
+    media::MediaStreamId,
     metadata::{ContainerFormat, SourceId},
     reader_mp4::{Mp4AudioReader, Mp4VideoReader},
     reader_webm::{WebmAudioReader, WebmVideoReader},
@@ -52,11 +53,17 @@ pub fn run(mut args: noargs::RawArgs) -> noargs::Result<()> {
 
     let dummy_source_id = SourceId::new("inspect"); // 使われないのでなんでもいい
 
+    let audio_stream_id = MediaStreamId::new(0);
     let (audio_reader, video_reader): (Box<dyn Iterator<Item = _>>, Box<dyn Iterator<Item = _>>) =
         match format {
             ContainerFormat::Webm => {
                 let audio = Box::new(
-                    WebmAudioReader::new(dummy_source_id.clone(), &input_file_path).or_fail()?,
+                    WebmAudioReader::new(
+                        dummy_source_id.clone(),
+                        audio_stream_id,
+                        &input_file_path,
+                    )
+                    .or_fail()?,
                 );
                 let video = Box::new(
                     WebmVideoReader::new(dummy_source_id.clone(), &input_file_path).or_fail()?,
@@ -65,7 +72,8 @@ pub fn run(mut args: noargs::RawArgs) -> noargs::Result<()> {
             }
             ContainerFormat::Mp4 => {
                 let audio = Box::new(
-                    Mp4AudioReader::new(dummy_source_id.clone(), &input_file_path).or_fail()?,
+                    Mp4AudioReader::new(dummy_source_id.clone(), audio_stream_id, &input_file_path)
+                        .or_fail()?,
                 );
                 let video = Box::new(
                     Mp4VideoReader::new(dummy_source_id.clone(), &input_file_path).or_fail()?,

--- a/src/subcommand_vmaf.rs
+++ b/src/subcommand_vmaf.rs
@@ -15,6 +15,7 @@ use crate::{
     encoder::{VideoEncoder, VideoEncoderThread},
     json::JsonObject,
     layout::Layout,
+    media::MediaStreamId,
     mixer_video::VideoMixerThread,
     stats::{Seconds, SharedStats, VideoDecoderStats},
     types::EngineName,
@@ -214,7 +215,8 @@ pub fn run(mut raw_args: noargs::RawArgs) -> noargs::Result<()> {
     let options = VideoDecoderOptions {
         openh264_lib: openh264_lib.clone(),
     };
-    let mut decoder = VideoDecoder::new(options);
+    let dummy_stream_id = MediaStreamId::new(0);
+    let mut decoder = VideoDecoder::new(dummy_stream_id, dummy_stream_id, options);
     let distorted_yuv_file_path = args.root_dir.join(&args.distorted_yuv_file_path);
     let mut distorted_yuv_writer = YuvWriter::new(&distorted_yuv_file_path).or_fail()?;
 

--- a/src/subcommand_vmaf.rs
+++ b/src/subcommand_vmaf.rs
@@ -17,7 +17,7 @@ use crate::{
     layout::Layout,
     media::MediaStreamId,
     mixer_video::VideoMixerThread,
-    stats::{Seconds, SharedStats, VideoDecoderStats},
+    stats::{Seconds, SharedStats},
     types::EngineName,
     video::FrameRate,
     writer_yuv::YuvWriter,
@@ -222,7 +222,6 @@ pub fn run(mut raw_args: noargs::RawArgs) -> noargs::Result<()> {
 
     // 必要なフレームの処理が終わるまでループを回す
     eprintln!("# Compose for VMAF");
-    let mut dummy_video_decoder_stats = VideoDecoderStats::default();
     let mut encoded_byte_size = 0;
     let mut encoded_duration = Duration::ZERO;
     let mut encoded_frame_count = 0;
@@ -242,9 +241,7 @@ pub fn run(mut raw_args: noargs::RawArgs) -> noargs::Result<()> {
         };
         encoded_byte_size += encoded_frame.data.len() as u64;
         encoded_duration += encoded_frame.duration;
-        decoder
-            .decode(encoded_frame, &mut dummy_video_decoder_stats)
-            .or_fail()?;
+        decoder.decode(encoded_frame).or_fail()?;
         while let Some(decoded_frame) = decoder.next_decoded_frame() {
             distorted_yuv_writer.append(&decoded_frame).or_fail()?;
             progress_bar.inc(1);

--- a/src/video.rs
+++ b/src/video.rs
@@ -25,6 +25,20 @@ pub struct VideoFrame {
 }
 
 impl VideoFrame {
+    pub fn to_stripped(&self) -> Self {
+        Self {
+            source_id: self.source_id.clone(),
+            data: Vec::new(),
+            format: self.format,
+            keyframe: self.keyframe,
+            width: self.width,
+            height: self.height,
+            timestamp: self.timestamp,
+            duration: self.duration,
+            sample_entry: None,
+        }
+    }
+
     #[expect(clippy::too_many_arguments)]
     pub fn new_i420(
         input_frame: Self,

--- a/tests/decoder_tests.rs
+++ b/tests/decoder_tests.rs
@@ -26,7 +26,7 @@ fn h264_multi_resolutions() -> orfail::Result<()> {
     let reader1 = Mp4VideoReader::new(
         source_id1,
         DUMMY_STREAM_ID,
-        "tstdata/archive-red-320x320-h264.mp4",
+        "testdata/archive-red-320x320-h264.mp4",
     )
     .or_fail()?;
     multi_resolutions_test(reader0, reader1).or_fail()?;
@@ -41,13 +41,13 @@ fn h265_multi_resolutions() -> orfail::Result<()> {
     let reader0 = Mp4VideoReader::new(
         source_id0,
         DUMMY_STREAM_ID,
-        "tstdata/archive-blue-640x480-h265.mp4",
+        "testdata/archive-blue-640x480-h265.mp4",
     )
     .or_fail()?;
     let reader1 = Mp4VideoReader::new(
         source_id1,
         DUMMY_STREAM_ID,
-        "tstdata/archive-red-320x320-h265.mp4",
+        "testdata/archive-red-320x320-h265.mp4",
     )
     .or_fail()?;
     multi_resolutions_test(reader0, reader1).or_fail()?;
@@ -61,13 +61,13 @@ fn vp9_multi_resolutions() -> orfail::Result<()> {
     let reader0 = Mp4VideoReader::new(
         source_id0,
         DUMMY_STREAM_ID,
-        "tstdata/archive-blue-640x480-vp9.mp4",
+        "testdata/archive-blue-640x480-vp9.mp4",
     )
     .or_fail()?;
     let reader1 = Mp4VideoReader::new(
         source_id1,
         DUMMY_STREAM_ID,
-        "tstdata/archive-red-320x320-vp9.mp4",
+        "testdata/archive-red-320x320-vp9.mp4",
     )
     .or_fail()?;
     multi_resolutions_test(reader0, reader1).or_fail()?;
@@ -81,13 +81,13 @@ fn av1_multi_resolutions() -> orfail::Result<()> {
     let reader0 = Mp4VideoReader::new(
         source_id0,
         DUMMY_STREAM_ID,
-        "tstdata/archive-blue-640x480-av1.mp4",
+        "testdata/archive-blue-640x480-av1.mp4",
     )
     .or_fail()?;
     let reader1 = Mp4VideoReader::new(
         source_id1,
         DUMMY_STREAM_ID,
-        "tstdata/archive-red-320x320-av1.mp4",
+        "testdata/archive-red-320x320-av1.mp4",
     )
     .or_fail()?;
     multi_resolutions_test(reader0, reader1).or_fail()?;

--- a/tests/decoder_tests.rs
+++ b/tests/decoder_tests.rs
@@ -1,5 +1,6 @@
 use hisui::{
     decoder::{VideoDecoder, VideoDecoderOptions},
+    media::MediaStreamId,
     metadata::SourceId,
     reader_mp4::Mp4VideoReader,
     stats::VideoDecoderStats,
@@ -9,14 +10,25 @@ use orfail::OrFail;
 use shiguredo_mp4::boxes::{Avc1Box, AvccBox, SampleEntry};
 use shiguredo_openh264::Openh264Library;
 
+// 実質的には使われないので値はなんでもいい
+const DUMMY_STREAM_ID: MediaStreamId = MediaStreamId::new(0);
+
 #[test]
 fn h264_multi_resolutions() -> orfail::Result<()> {
     let source_id0 = SourceId::new("archive-blue-640x480-h264");
     let source_id1 = SourceId::new("archive-blue-640x480-h264");
-    let reader0 =
-        Mp4VideoReader::new(source_id0, "testdata/archive-blue-640x480-h264.mp4").or_fail()?;
-    let reader1 =
-        Mp4VideoReader::new(source_id1, "testdata/archive-red-320x320-h264.mp4").or_fail()?;
+    let reader0 = Mp4VideoReader::new(
+        source_id0,
+        DUMMY_STREAM_ID,
+        "testdata/archive-blue-640x480-h264.mp4",
+    )
+    .or_fail()?;
+    let reader1 = Mp4VideoReader::new(
+        source_id1,
+        DUMMY_STREAM_ID,
+        "tstdata/archive-red-320x320-h264.mp4",
+    )
+    .or_fail()?;
     multi_resolutions_test(reader0, reader1).or_fail()?;
     Ok(())
 }
@@ -26,10 +38,18 @@ fn h264_multi_resolutions() -> orfail::Result<()> {
 fn h265_multi_resolutions() -> orfail::Result<()> {
     let source_id0 = SourceId::new("archive-blue-640x480-h265");
     let source_id1 = SourceId::new("archive-red-320x320-h265");
-    let reader0 =
-        Mp4VideoReader::new(source_id0, "testdata/archive-blue-640x480-h265.mp4").or_fail()?;
-    let reader1 =
-        Mp4VideoReader::new(source_id1, "testdata/archive-red-320x320-h265.mp4").or_fail()?;
+    let reader0 = Mp4VideoReader::new(
+        source_id0,
+        DUMMY_STREAM_ID,
+        "tstdata/archive-blue-640x480-h265.mp4",
+    )
+    .or_fail()?;
+    let reader1 = Mp4VideoReader::new(
+        source_id1,
+        DUMMY_STREAM_ID,
+        "tstdata/archive-red-320x320-h265.mp4",
+    )
+    .or_fail()?;
     multi_resolutions_test(reader0, reader1).or_fail()?;
     Ok(())
 }
@@ -38,10 +58,18 @@ fn h265_multi_resolutions() -> orfail::Result<()> {
 fn vp9_multi_resolutions() -> orfail::Result<()> {
     let source_id0 = SourceId::new("archive-blue-640x480-vp9");
     let source_id1 = SourceId::new("archive-red-320x320-vp9");
-    let reader0 =
-        Mp4VideoReader::new(source_id0, "testdata/archive-blue-640x480-vp9.mp4").or_fail()?;
-    let reader1 =
-        Mp4VideoReader::new(source_id1, "testdata/archive-red-320x320-vp9.mp4").or_fail()?;
+    let reader0 = Mp4VideoReader::new(
+        source_id0,
+        DUMMY_STREAM_ID,
+        "tstdata/archive-blue-640x480-vp9.mp4",
+    )
+    .or_fail()?;
+    let reader1 = Mp4VideoReader::new(
+        source_id1,
+        DUMMY_STREAM_ID,
+        "tstdata/archive-red-320x320-vp9.mp4",
+    )
+    .or_fail()?;
     multi_resolutions_test(reader0, reader1).or_fail()?;
     Ok(())
 }
@@ -50,10 +78,18 @@ fn vp9_multi_resolutions() -> orfail::Result<()> {
 fn av1_multi_resolutions() -> orfail::Result<()> {
     let source_id0 = SourceId::new("archive-blue-640x480-av1");
     let source_id1 = SourceId::new("archive-red-320x320-av1");
-    let reader0 =
-        Mp4VideoReader::new(source_id0, "testdata/archive-blue-640x480-av1.mp4").or_fail()?;
-    let reader1 =
-        Mp4VideoReader::new(source_id1, "testdata/archive-red-320x320-av1.mp4").or_fail()?;
+    let reader0 = Mp4VideoReader::new(
+        source_id0,
+        DUMMY_STREAM_ID,
+        "tstdata/archive-blue-640x480-av1.mp4",
+    )
+    .or_fail()?;
+    let reader1 = Mp4VideoReader::new(
+        source_id1,
+        DUMMY_STREAM_ID,
+        "tstdata/archive-red-320x320-av1.mp4",
+    )
+    .or_fail()?;
     multi_resolutions_test(reader0, reader1).or_fail()?;
     Ok(())
 }

--- a/tests/decoder_tests.rs
+++ b/tests/decoder_tests.rs
@@ -3,7 +3,6 @@ use hisui::{
     media::MediaStreamId,
     metadata::SourceId,
     reader_mp4::Mp4VideoReader,
-    stats::VideoDecoderStats,
     video::VideoFrame,
 };
 use orfail::OrFail;
@@ -63,7 +62,6 @@ fn multi_resolutions_test<I>(reader0: I, reader1: I) -> orfail::Result<()>
 where
     I: Iterator<Item = orfail::Result<VideoFrame>>,
 {
-    let mut stats = VideoDecoderStats::default();
     let options = VideoDecoderOptions {
         openh264_lib: if let Ok(path) = std::env::var("OPENH264_PATH") {
             Some(Openh264Library::load(path).or_fail()?)
@@ -86,7 +84,7 @@ where
 
     for input_frame in reader0 {
         let input_frame = prepend_h264_sps_pps(input_frame.or_fail()?);
-        decoder.decode(input_frame, &mut stats).or_fail()?;
+        decoder.decode(input_frame).or_fail()?;
         blue_count += 1;
         while let Some(output_frame) = decoder.next_decoded_frame() {
             output_frames.push(output_frame);
@@ -96,7 +94,7 @@ where
     // このタイミングで解像度などが切り替わる
     for input_frame in reader1 {
         let input_frame = prepend_h264_sps_pps(input_frame.or_fail()?);
-        decoder.decode(input_frame, &mut stats).or_fail()?;
+        decoder.decode(input_frame).or_fail()?;
         red_count += 1;
         while let Some(output_frame) = decoder.next_decoded_frame() {
             output_frames.push(output_frame);

--- a/tests/decoder_tests.rs
+++ b/tests/decoder_tests.rs
@@ -1,5 +1,6 @@
 use hisui::{
     decoder::{VideoDecoder, VideoDecoderOptions},
+    media::MediaStreamId,
     metadata::SourceId,
     reader_mp4::Mp4VideoReader,
     stats::VideoDecoderStats,
@@ -76,7 +77,9 @@ where
     };
 
     // デコードする
-    let mut decoder = VideoDecoder::new(options);
+    let input_stream_id = MediaStreamId::new(0);
+    let output_stream_id = MediaStreamId::new(0);
+    let mut decoder = VideoDecoder::new(input_stream_id, output_stream_id, options);
     let mut output_frames = Vec::new();
     let mut blue_count = 0;
     let mut red_count = 0;

--- a/tests/decoder_tests.rs
+++ b/tests/decoder_tests.rs
@@ -1,6 +1,5 @@
 use hisui::{
     decoder::{VideoDecoder, VideoDecoderOptions},
-    media::MediaStreamId,
     metadata::SourceId,
     reader_mp4::Mp4VideoReader,
     stats::VideoDecoderStats,
@@ -10,25 +9,14 @@ use orfail::OrFail;
 use shiguredo_mp4::boxes::{Avc1Box, AvccBox, SampleEntry};
 use shiguredo_openh264::Openh264Library;
 
-// 実質的には使われないので値はなんでもいい
-const DUMMY_STREAM_ID: MediaStreamId = MediaStreamId::new(0);
-
 #[test]
 fn h264_multi_resolutions() -> orfail::Result<()> {
     let source_id0 = SourceId::new("archive-blue-640x480-h264");
     let source_id1 = SourceId::new("archive-blue-640x480-h264");
-    let reader0 = Mp4VideoReader::new(
-        source_id0,
-        DUMMY_STREAM_ID,
-        "testdata/archive-blue-640x480-h264.mp4",
-    )
-    .or_fail()?;
-    let reader1 = Mp4VideoReader::new(
-        source_id1,
-        DUMMY_STREAM_ID,
-        "testdata/archive-red-320x320-h264.mp4",
-    )
-    .or_fail()?;
+    let reader0 =
+        Mp4VideoReader::new(source_id0, "testdata/archive-blue-640x480-h264.mp4").or_fail()?;
+    let reader1 =
+        Mp4VideoReader::new(source_id1, "testdata/archive-red-320x320-h264.mp4").or_fail()?;
     multi_resolutions_test(reader0, reader1).or_fail()?;
     Ok(())
 }
@@ -38,18 +26,10 @@ fn h264_multi_resolutions() -> orfail::Result<()> {
 fn h265_multi_resolutions() -> orfail::Result<()> {
     let source_id0 = SourceId::new("archive-blue-640x480-h265");
     let source_id1 = SourceId::new("archive-red-320x320-h265");
-    let reader0 = Mp4VideoReader::new(
-        source_id0,
-        DUMMY_STREAM_ID,
-        "testdata/archive-blue-640x480-h265.mp4",
-    )
-    .or_fail()?;
-    let reader1 = Mp4VideoReader::new(
-        source_id1,
-        DUMMY_STREAM_ID,
-        "testdata/archive-red-320x320-h265.mp4",
-    )
-    .or_fail()?;
+    let reader0 =
+        Mp4VideoReader::new(source_id0, "testdata/archive-blue-640x480-h265.mp4").or_fail()?;
+    let reader1 =
+        Mp4VideoReader::new(source_id1, "testdata/archive-red-320x320-h265.mp4").or_fail()?;
     multi_resolutions_test(reader0, reader1).or_fail()?;
     Ok(())
 }
@@ -58,18 +38,10 @@ fn h265_multi_resolutions() -> orfail::Result<()> {
 fn vp9_multi_resolutions() -> orfail::Result<()> {
     let source_id0 = SourceId::new("archive-blue-640x480-vp9");
     let source_id1 = SourceId::new("archive-red-320x320-vp9");
-    let reader0 = Mp4VideoReader::new(
-        source_id0,
-        DUMMY_STREAM_ID,
-        "testdata/archive-blue-640x480-vp9.mp4",
-    )
-    .or_fail()?;
-    let reader1 = Mp4VideoReader::new(
-        source_id1,
-        DUMMY_STREAM_ID,
-        "testdata/archive-red-320x320-vp9.mp4",
-    )
-    .or_fail()?;
+    let reader0 =
+        Mp4VideoReader::new(source_id0, "testdata/archive-blue-640x480-vp9.mp4").or_fail()?;
+    let reader1 =
+        Mp4VideoReader::new(source_id1, "testdata/archive-red-320x320-vp9.mp4").or_fail()?;
     multi_resolutions_test(reader0, reader1).or_fail()?;
     Ok(())
 }
@@ -78,18 +50,10 @@ fn vp9_multi_resolutions() -> orfail::Result<()> {
 fn av1_multi_resolutions() -> orfail::Result<()> {
     let source_id0 = SourceId::new("archive-blue-640x480-av1");
     let source_id1 = SourceId::new("archive-red-320x320-av1");
-    let reader0 = Mp4VideoReader::new(
-        source_id0,
-        DUMMY_STREAM_ID,
-        "testdata/archive-blue-640x480-av1.mp4",
-    )
-    .or_fail()?;
-    let reader1 = Mp4VideoReader::new(
-        source_id1,
-        DUMMY_STREAM_ID,
-        "testdata/archive-red-320x320-av1.mp4",
-    )
-    .or_fail()?;
+    let reader0 =
+        Mp4VideoReader::new(source_id0, "testdata/archive-blue-640x480-av1.mp4").or_fail()?;
+    let reader1 =
+        Mp4VideoReader::new(source_id1, "testdata/archive-red-320x320-av1.mp4").or_fail()?;
     multi_resolutions_test(reader0, reader1).or_fail()?;
     Ok(())
 }

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 use hisui::{
     decoder_libvpx::LibvpxDecoder,
     decoder_opus::OpusDecoder,
+    media::MediaStreamId,
     metadata::SourceId,
     reader_mp4::{Mp4AudioReader, Mp4VideoReader},
     stats::ProcessorStats,
@@ -10,6 +11,9 @@ use hisui::{
     types::CodecName,
 };
 use orfail::OrFail;
+
+// 実質的には使われないので値はなんでもいい
+const DUMMY_STREAM_ID: MediaStreamId = MediaStreamId::new(0);
 
 /// ソースが空の場合
 #[test]
@@ -33,13 +37,13 @@ fn empty_source() -> noargs::Result<()> {
     // 結果ファイルを確認（映像・音声トラックが存在しない）
     assert!(out_file.path().exists());
     assert_eq!(
-        Mp4AudioReader::new(SourceId::new("dummy"), out_file.path())
+        Mp4AudioReader::new(SourceId::new("dummy"), DUMMY_STREAM_ID, out_file.path())
             .or_fail()?
             .count(),
         0
     );
     assert_eq!(
-        Mp4VideoReader::new(SourceId::new("dummy"), out_file.path())
+        Mp4VideoReader::new(SourceId::new("dummy"), DUMMY_STREAM_ID, out_file.path())
             .or_fail()?
             .count(),
         0
@@ -81,9 +85,9 @@ fn simple_single_source() -> noargs::Result<()> {
     // 変換結果ファイルを読み込む
     assert!(out_file.path().exists());
     let mut audio_reader =
-        Mp4AudioReader::new(SourceId::new("dummy"), out_file.path()).or_fail()?;
+        Mp4AudioReader::new(SourceId::new("dummy"), DUMMY_STREAM_ID, out_file.path()).or_fail()?;
     let mut video_reader =
-        Mp4VideoReader::new(SourceId::new("dummy"), out_file.path()).or_fail()?;
+        Mp4VideoReader::new(SourceId::new("dummy"), DUMMY_STREAM_ID, out_file.path()).or_fail()?;
 
     // 後でデコードするために読み込み結果を覚えておく
     let audio_samples = audio_reader.by_ref().collect::<orfail::Result<Vec<_>>>()?;
@@ -179,9 +183,9 @@ fn simple_multi_sources() -> noargs::Result<()> {
     // 変換結果ファイルを読み込む
     assert!(out_file.path().exists());
     let mut audio_reader =
-        Mp4AudioReader::new(SourceId::new("dummy"), out_file.path()).or_fail()?;
+        Mp4AudioReader::new(SourceId::new("dummy"), DUMMY_STREAM_ID, out_file.path()).or_fail()?;
     let mut video_reader =
-        Mp4VideoReader::new(SourceId::new("dummy"), out_file.path()).or_fail()?;
+        Mp4VideoReader::new(SourceId::new("dummy"), DUMMY_STREAM_ID, out_file.path()).or_fail()?;
 
     // [NOTE]
     // レイアウトファイル未指定だと映像の解像度が大きめになって
@@ -255,9 +259,9 @@ fn multi_sources_single_column() -> noargs::Result<()> {
     // 変換結果ファイルを読み込む
     assert!(out_file.path().exists());
     let mut audio_reader =
-        Mp4AudioReader::new(SourceId::new("dummy"), out_file.path()).or_fail()?;
+        Mp4AudioReader::new(SourceId::new("dummy"), DUMMY_STREAM_ID, out_file.path()).or_fail()?;
     let mut video_reader =
-        Mp4VideoReader::new(SourceId::new("dummy"), out_file.path()).or_fail()?;
+        Mp4VideoReader::new(SourceId::new("dummy"), DUMMY_STREAM_ID, out_file.path()).or_fail()?;
 
     // 後でデコードするために読み込み結果を覚えておく
     let audio_samples = audio_reader.by_ref().collect::<orfail::Result<Vec<_>>>()?;
@@ -376,11 +380,11 @@ fn two_regions() -> noargs::Result<()> {
     // 変換結果ファイルを読み込む
     assert!(out_file.path().exists());
     let mut video_reader =
-        Mp4VideoReader::new(SourceId::new("dummy"), out_file.path()).or_fail()?;
+        Mp4VideoReader::new(SourceId::new("dummy"), DUMMY_STREAM_ID, out_file.path()).or_fail()?;
 
     // 音声はなし
     assert_eq!(
-        Mp4AudioReader::new(SourceId::new("dummy"), out_file.path())
+        Mp4AudioReader::new(SourceId::new("dummy"), DUMMY_STREAM_ID, out_file.path())
             .or_fail()?
             .count(),
         0

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -37,7 +37,7 @@ fn empty_source() -> noargs::Result<()> {
     // 結果ファイルを確認（映像・音声トラックが存在しない）
     assert!(out_file.path().exists());
     assert_eq!(
-        Mp4AudioReader::new(SourceId::new("dummy"), DUMMY_STREAM_ID, out_file.path())
+        Mp4AudioReader::new(SourceId::new("dummy"), out_file.path())
             .or_fail()?
             .count(),
         0
@@ -85,7 +85,7 @@ fn simple_single_source() -> noargs::Result<()> {
     // 変換結果ファイルを読み込む
     assert!(out_file.path().exists());
     let mut audio_reader =
-        Mp4AudioReader::new(SourceId::new("dummy"), DUMMY_STREAM_ID, out_file.path()).or_fail()?;
+        Mp4AudioReader::new(SourceId::new("dummy"), out_file.path()).or_fail()?;
     let mut video_reader =
         Mp4VideoReader::new(SourceId::new("dummy"), DUMMY_STREAM_ID, out_file.path()).or_fail()?;
 
@@ -94,9 +94,7 @@ fn simple_single_source() -> noargs::Result<()> {
     let video_samples = video_reader.by_ref().collect::<orfail::Result<Vec<_>>>()?;
 
     // 統計値を確認
-    let ProcessorStats::Mp4AudioReader(audio_stats) = audio_reader.stats() else {
-        unreachable!()
-    };
+    let audio_stats = audio_reader.stats();
     assert_eq!(audio_stats.codec.get(), Some(CodecName::Opus));
 
     // 一秒分 + 一サンプル (25 ms)
@@ -183,7 +181,7 @@ fn simple_multi_sources() -> noargs::Result<()> {
     // 変換結果ファイルを読み込む
     assert!(out_file.path().exists());
     let mut audio_reader =
-        Mp4AudioReader::new(SourceId::new("dummy"), DUMMY_STREAM_ID, out_file.path()).or_fail()?;
+        Mp4AudioReader::new(SourceId::new("dummy"), out_file.path()).or_fail()?;
     let mut video_reader =
         Mp4VideoReader::new(SourceId::new("dummy"), DUMMY_STREAM_ID, out_file.path()).or_fail()?;
 
@@ -195,9 +193,7 @@ fn simple_multi_sources() -> noargs::Result<()> {
     let _video_samples = video_reader.by_ref().collect::<orfail::Result<Vec<_>>>()?;
 
     // 統計値を確認
-    let ProcessorStats::Mp4AudioReader(audio_stats) = audio_reader.stats() else {
-        unreachable!()
-    };
+    let audio_stats = audio_reader.stats();
     assert_eq!(audio_stats.codec.get(), Some(CodecName::Opus));
 
     // 一秒分 + 一サンプル (25 ms)
@@ -259,7 +255,7 @@ fn multi_sources_single_column() -> noargs::Result<()> {
     // 変換結果ファイルを読み込む
     assert!(out_file.path().exists());
     let mut audio_reader =
-        Mp4AudioReader::new(SourceId::new("dummy"), DUMMY_STREAM_ID, out_file.path()).or_fail()?;
+        Mp4AudioReader::new(SourceId::new("dummy"), out_file.path()).or_fail()?;
     let mut video_reader =
         Mp4VideoReader::new(SourceId::new("dummy"), DUMMY_STREAM_ID, out_file.path()).or_fail()?;
 
@@ -268,9 +264,7 @@ fn multi_sources_single_column() -> noargs::Result<()> {
     let video_samples = video_reader.by_ref().collect::<orfail::Result<Vec<_>>>()?;
 
     // 統計値を確認
-    let ProcessorStats::Mp4AudioReader(audio_stats) = audio_reader.stats() else {
-        unreachable!()
-    };
+    let audio_stats = audio_reader.stats();
     assert_eq!(audio_stats.codec.get(), Some(CodecName::Opus));
 
     // 一秒分 + 一サンプル (25 ms)
@@ -384,7 +378,7 @@ fn two_regions() -> noargs::Result<()> {
 
     // 音声はなし
     assert_eq!(
-        Mp4AudioReader::new(SourceId::new("dummy"), DUMMY_STREAM_ID, out_file.path())
+        Mp4AudioReader::new(SourceId::new("dummy"), out_file.path())
             .or_fail()?
             .count(),
         0

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -3,17 +3,12 @@ use std::time::Duration;
 use hisui::{
     decoder_libvpx::LibvpxDecoder,
     decoder_opus::OpusDecoder,
-    media::MediaStreamId,
     metadata::SourceId,
     reader_mp4::{Mp4AudioReader, Mp4VideoReader},
-    stats::ProcessorStats,
     subcommand_legacy::{Args, Runner},
     types::CodecName,
 };
 use orfail::OrFail;
-
-// 実質的には使われないので値はなんでもいい
-const DUMMY_STREAM_ID: MediaStreamId = MediaStreamId::new(0);
 
 /// ソースが空の場合
 #[test]
@@ -43,7 +38,7 @@ fn empty_source() -> noargs::Result<()> {
         0
     );
     assert_eq!(
-        Mp4VideoReader::new(SourceId::new("dummy"), DUMMY_STREAM_ID, out_file.path())
+        Mp4VideoReader::new(SourceId::new("dummy"), out_file.path())
             .or_fail()?
             .count(),
         0
@@ -87,7 +82,7 @@ fn simple_single_source() -> noargs::Result<()> {
     let mut audio_reader =
         Mp4AudioReader::new(SourceId::new("dummy"), out_file.path()).or_fail()?;
     let mut video_reader =
-        Mp4VideoReader::new(SourceId::new("dummy"), DUMMY_STREAM_ID, out_file.path()).or_fail()?;
+        Mp4VideoReader::new(SourceId::new("dummy"), out_file.path()).or_fail()?;
 
     // 後でデコードするために読み込み結果を覚えておく
     let audio_samples = audio_reader.by_ref().collect::<orfail::Result<Vec<_>>>()?;
@@ -105,9 +100,7 @@ fn simple_single_source() -> noargs::Result<()> {
         Duration::from_millis(1020)
     );
 
-    let ProcessorStats::Mp4VideoReader(video_stats) = video_reader.stats() else {
-        unreachable!()
-    };
+    let video_stats = video_reader.stats();
     assert_eq!(video_stats.codec.get(), Some(CodecName::Vp9));
     assert_eq!(
         video_stats
@@ -183,7 +176,7 @@ fn simple_multi_sources() -> noargs::Result<()> {
     let mut audio_reader =
         Mp4AudioReader::new(SourceId::new("dummy"), out_file.path()).or_fail()?;
     let mut video_reader =
-        Mp4VideoReader::new(SourceId::new("dummy"), DUMMY_STREAM_ID, out_file.path()).or_fail()?;
+        Mp4VideoReader::new(SourceId::new("dummy"), out_file.path()).or_fail()?;
 
     // [NOTE]
     // レイアウトファイル未指定だと映像の解像度が大きめになって
@@ -204,9 +197,7 @@ fn simple_multi_sources() -> noargs::Result<()> {
         Duration::from_millis(1020)
     );
 
-    let ProcessorStats::Mp4VideoReader(video_stats) = video_reader.stats() else {
-        unreachable!()
-    };
+    let video_stats = video_reader.stats();
     assert_eq!(video_stats.codec.get(), Some(CodecName::Vp9));
 
     // レイアウトファイル未指定の場合には、一つのセルの解像度は 320x240 で、
@@ -257,7 +248,7 @@ fn multi_sources_single_column() -> noargs::Result<()> {
     let mut audio_reader =
         Mp4AudioReader::new(SourceId::new("dummy"), out_file.path()).or_fail()?;
     let mut video_reader =
-        Mp4VideoReader::new(SourceId::new("dummy"), DUMMY_STREAM_ID, out_file.path()).or_fail()?;
+        Mp4VideoReader::new(SourceId::new("dummy"), out_file.path()).or_fail()?;
 
     // 後でデコードするために読み込み結果を覚えておく
     let audio_samples = audio_reader.by_ref().collect::<orfail::Result<Vec<_>>>()?;
@@ -275,9 +266,7 @@ fn multi_sources_single_column() -> noargs::Result<()> {
         Duration::from_millis(1020)
     );
 
-    let ProcessorStats::Mp4VideoReader(video_stats) = video_reader.stats() else {
-        unreachable!()
-    };
+    let video_stats = video_reader.stats();
     assert_eq!(video_stats.codec.get(), Some(CodecName::Vp9));
     assert_eq!(
         video_stats
@@ -374,7 +363,7 @@ fn two_regions() -> noargs::Result<()> {
     // 変換結果ファイルを読み込む
     assert!(out_file.path().exists());
     let mut video_reader =
-        Mp4VideoReader::new(SourceId::new("dummy"), DUMMY_STREAM_ID, out_file.path()).or_fail()?;
+        Mp4VideoReader::new(SourceId::new("dummy"), out_file.path()).or_fail()?;
 
     // 音声はなし
     assert_eq!(
@@ -388,9 +377,7 @@ fn two_regions() -> noargs::Result<()> {
     let video_samples = video_reader.by_ref().collect::<orfail::Result<Vec<_>>>()?;
 
     // 統計値を確認
-    let ProcessorStats::Mp4VideoReader(video_stats) = video_reader.stats() else {
-        unreachable!()
-    };
+    let video_stats = video_reader.stats();
     assert_eq!(video_stats.codec.get(), Some(CodecName::Vp9));
     assert_eq!(
         video_stats

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -143,7 +143,7 @@ fn simple_single_source() -> noargs::Result<()> {
 
     let mut decoder = LibvpxDecoder::new_vp9().or_fail()?;
     for frame in video_samples {
-        decoder.decode(frame).or_fail()?;
+        decoder.decode(&frame).or_fail()?;
         check_decoded_frames(&mut decoder).or_fail()?;
     }
     decoder.finish().or_fail()?;
@@ -328,7 +328,7 @@ fn multi_sources_single_column() -> noargs::Result<()> {
 
     let mut decoder = LibvpxDecoder::new_vp9().or_fail()?;
     for frame in video_samples {
-        decoder.decode(frame).or_fail()?;
+        decoder.decode(&frame).or_fail()?;
         check_decoded_frames(&mut decoder).or_fail()?;
     }
     decoder.finish().or_fail()?;
@@ -430,7 +430,7 @@ fn two_regions() -> noargs::Result<()> {
 
     let mut decoder = LibvpxDecoder::new_vp9().or_fail()?;
     for frame in video_samples {
-        decoder.decode(frame).or_fail()?;
+        decoder.decode(&frame).or_fail()?;
         check_decoded_frames(&mut decoder).or_fail()?;
     }
     decoder.finish().or_fail()?;

--- a/tests/reader_webm_test.rs
+++ b/tests/reader_webm_test.rs
@@ -1,12 +1,8 @@
 use hisui::{
-    media::MediaStreamId,
     metadata::SourceId,
     reader_webm::{WebmAudioReader, WebmVideoReader},
 };
 use orfail::OrFail;
-
-// 実質的には使われないので値はなんでもいい
-const DUMMY_STREAM_ID: MediaStreamId = MediaStreamId::new(0);
 
 #[test]
 fn webm_audio_reader_test() -> orfail::Result<()> {
@@ -20,12 +16,8 @@ fn webm_audio_reader_test() -> orfail::Result<()> {
 
 #[test]
 fn webm_video_reader_test() -> orfail::Result<()> {
-    let reader = WebmVideoReader::new(
-        SourceId::new("dummy"),
-        DUMMY_STREAM_ID,
-        "testdata/archive-black-silent.webm",
-    )
-    .or_fail()?;
+    let reader = WebmVideoReader::new(SourceId::new("dummy"), "testdata/archive-black-silent.webm")
+        .or_fail()?;
     for video_frame in reader {
         video_frame.or_fail()?;
     }

--- a/tests/reader_webm_test.rs
+++ b/tests/reader_webm_test.rs
@@ -1,13 +1,21 @@
 use hisui::{
+    media::MediaStreamId,
     metadata::SourceId,
     reader_webm::{WebmAudioReader, WebmVideoReader},
 };
 use orfail::OrFail;
 
+// 実質的には使われないので値はなんでもいい
+const DUMMY_STREAM_ID: MediaStreamId = MediaStreamId::new(0);
+
 #[test]
 fn webm_audio_reader_test() -> orfail::Result<()> {
-    let reader = WebmAudioReader::new(SourceId::new("dummy"), "testdata/archive-black-silent.webm")
-        .or_fail()?;
+    let reader = WebmAudioReader::new(
+        SourceId::new("dummy"),
+        DUMMY_STREAM_ID,
+        "testdata/archive-black-silent.webm",
+    )
+    .or_fail()?;
     for audio_data in reader {
         audio_data.or_fail()?;
     }
@@ -16,8 +24,12 @@ fn webm_audio_reader_test() -> orfail::Result<()> {
 
 #[test]
 fn webm_video_reader_test() -> orfail::Result<()> {
-    let reader = WebmVideoReader::new(SourceId::new("dummy"), "testdata/archive-black-silent.webm")
-        .or_fail()?;
+    let reader = WebmVideoReader::new(
+        SourceId::new("dummy"),
+        DUMMY_STREAM_ID,
+        "testdata/archive-black-silent.webm",
+    )
+    .or_fail()?;
     for video_frame in reader {
         video_frame.or_fail()?;
     }

--- a/tests/reader_webm_test.rs
+++ b/tests/reader_webm_test.rs
@@ -10,12 +10,8 @@ const DUMMY_STREAM_ID: MediaStreamId = MediaStreamId::new(0);
 
 #[test]
 fn webm_audio_reader_test() -> orfail::Result<()> {
-    let reader = WebmAudioReader::new(
-        SourceId::new("dummy"),
-        DUMMY_STREAM_ID,
-        "testdata/archive-black-silent.webm",
-    )
-    .or_fail()?;
+    let reader = WebmAudioReader::new(SourceId::new("dummy"), "testdata/archive-black-silent.webm")
+        .or_fail()?;
     for audio_data in reader {
         audio_data.or_fail()?;
     }


### PR DESCRIPTION
各処理コンポーネントのインターフェース共通化用に `MediaProcessor` トレイトを導入する。
この PR では reader および decoder でのトレイト実装のみを対象とし、それ以外は後続の PR で対応する。