### PR TITLE
MediaPipeline のエラーハンドリング周りの整理

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,9 +488,9 @@ checksum = "9e5dc223a8d69eaeb19c31218a69a55112fe79965764430f092532aed848f1b8"
 
 [[package]]
 name = "nojson"
-version = "0.3.6"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20f9facf70a088279ffcf06cb5f897660ebd32621629b51872f4d4b25c77e494"
+checksum = "a86b88848c0847cfa64a48ad5c776ed2dbb0cc8fe1241ab20939a101ff7e1465"
 
 [[package]]
 name = "nom"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ libvpx = ["shiguredo_libvpx"]
 tracing = "=0.1.44"
 tracing-subscriber = { version = "=0.3.22", features = ["fmt", "std"] }
 noargs = "=0.4.2"
-nojson = "=0.3.6"
+nojson = "=0.3.8"
 orfail = "=2.0.0"
 rustls = { version = "=0.23.36", default-features = false, features = [
     "std",

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -64,10 +64,7 @@ impl AudioDecoder {
         output_track_id: TrackId,
     ) -> Result<()> {
         let mut input_rx = handle.subscribe_track(input_track_id);
-        let mut output_tx = handle
-            .publish_track(output_track_id)
-            .await
-            .ok_or_else(|| Error::new("Failed to publish audio track"))?;
+        let mut output_tx = handle.publish_track(output_track_id).await?;
 
         loop {
             let message = input_rx.recv().await;
@@ -285,10 +282,7 @@ impl VideoDecoder {
         output_track_id: TrackId,
     ) -> Result<()> {
         let mut input_rx = handle.subscribe_track(input_track_id);
-        let mut output_tx = handle
-            .publish_track(output_track_id)
-            .await
-            .ok_or_else(|| Error::new("Failed to publish video track"))?;
+        let mut output_tx = handle.publish_track(output_track_id).await?;
 
         loop {
             let message = input_rx.recv().await;

--- a/src/file_reader_mp4.rs
+++ b/src/file_reader_mp4.rs
@@ -82,10 +82,7 @@ impl Mp4FileReader {
     ) -> Result<(Option<TrackSender>, Option<TrackSender>)> {
         let audio_sender = match self.options.audio_track_id.take() {
             Some(track_id) => {
-                let sender = handle
-                    .publish_track(track_id)
-                    .await
-                    .ok_or_else(|| Error::new("Failed to publish audio track"))?;
+                let sender = handle.publish_track(track_id).await?;
                 Some(TrackSender::new(sender))
             }
             None => None,
@@ -93,10 +90,7 @@ impl Mp4FileReader {
 
         let video_sender = match self.options.video_track_id.take() {
             Some(track_id) => {
-                let sender = handle
-                    .publish_track(track_id)
-                    .await
-                    .ok_or_else(|| Error::new("Failed to publish video track"))?;
+                let sender = handle.publish_track(track_id).await?;
                 Some(TrackSender::new(sender))
             }
             None => None,

--- a/src/inbound_endpoint_rtmp.rs
+++ b/src/inbound_endpoint_rtmp.rs
@@ -53,11 +53,11 @@ impl RtmpInboundEndpoint {
     }
 
     /// Start the RTMP Inbound Endpoint
-    pub async fn run(self, handle: crate::ProcessorHandle) -> orfail::Result<()> {
+    pub async fn run(self, handle: crate::ProcessorHandle) -> crate::Result<()> {
         let addr = format!("{}:{}", self.url.host, self.url.port);
         tracing::debug!("Starting RTMP inbound endpoint on {addr}");
 
-        let listener = TcpListener::bind(&addr).await.or_fail()?;
+        let listener = TcpListener::bind(&addr).await?;
 
         let tls_enabled = self.url.tls;
         tracing::debug!(
@@ -66,12 +66,10 @@ impl RtmpInboundEndpoint {
         );
 
         let tls_acceptor = if tls_enabled {
-            let (cert_path, key_path) = self.get_cert_and_key_paths().or_fail()?;
-            Some(
-                create_server_tls_acceptor(&cert_path, &key_path)
-                    .await
-                    .or_fail()?,
-            )
+            let (cert_path, key_path) = self
+                .get_cert_and_key_paths()
+                .map_err(|e| crate::Error::new(e.to_string()))?;
+            Some(create_server_tls_acceptor(&cert_path, &key_path).await?)
         } else {
             None
         };
@@ -111,16 +109,14 @@ impl RtmpInboundEndpoint {
                             "{}_video",
                             self.url.stream_name
                         )))
-                        .await
-                        .or_fail()?;
+                        .await?;
 
                     let audio_track_tx = handle
                         .publish_track(crate::TrackId::new(format!(
                             "{}_audio",
                             self.url.stream_name
                         )))
-                        .await
-                        .or_fail()?;
+                        .await?;
 
                     tokio::spawn(async move {
                         let frame_handler_stats = crate::rtmp::RtmpIncomingFrameHandlerStats {
@@ -170,7 +166,7 @@ impl RtmpInboundEndpoint {
                         }
                     });
                 }
-                Ok(Err(e)) => return Err(e).or_fail(),
+                Ok(Err(e)) => return Err(e.into()),
                 Err(_) => {
                     tracing::info!("RTMP server lifetime expired, shutting down");
                     break;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,7 @@ pub use error::Error;
 pub use media::MediaSample;
 pub use media_pipeline::{
     Ack, MediaPipeline, MediaPipelineHandle, Message, MessageReceiver, MessageSender,
-    ProcessorHandle, ProcessorId, RegisterProcessorError, Syn, TrackId,
+    ProcessorHandle, ProcessorId, PublishTrackError, RegisterProcessorError, Syn, TrackId,
 };
 pub use video::VideoFrame;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,7 @@ pub use error::Error;
 pub use media::MediaSample;
 pub use media_pipeline::{
     Ack, MediaPipeline, MediaPipelineHandle, Message, MessageReceiver, MessageSender,
-    ProcessorHandle, ProcessorId, Syn, TrackId,
+    ProcessorHandle, ProcessorId, RegisterProcessorError, Syn, TrackId,
 };
 pub use video::VideoFrame;
 

--- a/src/media_pipeline.rs
+++ b/src/media_pipeline.rs
@@ -185,7 +185,7 @@ impl MediaPipelineHandle {
     ) -> Result<(), RegisterProcessorError>
     where
         F: FnOnce(ProcessorHandle) -> T + Send + 'static,
-        T: Future<Output = orfail::Result<()>> + Send,
+        T: Future<Output = crate::Result<()>> + Send,
     {
         let handle = self.register_processor(processor_id.clone()).await?;
         tokio::spawn(async move {
@@ -219,7 +219,7 @@ impl MediaPipelineHandle {
         }
     }
 
-    // すでに MediaPipeline が終了（中断）されている場合には false が返される。
+    // すでに MediaPipeline が終了している場合には false が返される。
     // なお、通常はこの結果をハンドリングする必要はない。
     // （コマンドの応答を受け取る場合は、その受信側で検知できるし、
     //   応答を受け取らない場合にはそもそもここの成功・失敗に依存するようなコマンドであるべきではないため）
@@ -377,7 +377,7 @@ impl ProcessorHandle {
 impl Drop for ProcessorHandle {
     fn drop(&mut self) {
         // 登録を解除する。
-        //パイプラインが中断されている場合には送信に失敗するが、そもそもその状況ではすでにエントリは削除されているので問題ないため、結果は無視する。
+        //パイプラインが終了している場合には送信に失敗するが、そもそもその状況ではすでにエントリは削除されているので問題ないため、結果は無視する。
         self.pipeline_handle.send(Command::DeregisterProcessor {
             processor_id: self.processor_id.clone(),
         });

--- a/src/media_pipeline.rs
+++ b/src/media_pipeline.rs
@@ -1,5 +1,3 @@
-use orfail::OrFail;
-
 #[derive(Debug)]
 pub struct MediaPipeline {
     command_tx: Option<tokio::sync::mpsc::UnboundedSender<Command>>,
@@ -180,15 +178,16 @@ pub struct MediaPipelineHandle {
 }
 
 impl MediaPipelineHandle {
-    pub async fn spawn_processor<F, T>(&self, processor_id: ProcessorId, f: F) -> orfail::Result<()>
+    pub async fn spawn_processor<F, T>(
+        &self,
+        processor_id: ProcessorId,
+        f: F,
+    ) -> Result<(), RegisterProcessorError>
     where
         F: FnOnce(ProcessorHandle) -> T + Send + 'static,
         T: Future<Output = orfail::Result<()>> + Send,
     {
-        let handle = self
-            .register_processor(processor_id.clone())
-            .await
-            .or_fail()?;
+        let handle = self.register_processor(processor_id.clone()).await?;
         tokio::spawn(async move {
             if let Err(e) = f(handle).await {
                 tracing::error!("failed to run processor {processor_id}: {e}");
@@ -197,20 +196,26 @@ impl MediaPipelineHandle {
         Ok(())
     }
 
-    async fn register_processor(&self, processor_id: ProcessorId) -> Option<ProcessorHandle> {
+    pub async fn register_processor(
+        &self,
+        processor_id: ProcessorId,
+    ) -> Result<ProcessorHandle, RegisterProcessorError> {
         let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
         let command = Command::RegisterProcessor {
             processor_id: processor_id.clone(),
             reply_tx,
         };
+
+        // [NOTE] パイプライン終了は次の rx で判定できるのでここでは返り値の考慮は不要
         self.send(command);
-        if let Ok(true) = reply_rx.await {
-            Some(ProcessorHandle {
+
+        match reply_rx.await {
+            Ok(true) => Ok(ProcessorHandle {
                 pipeline_handle: self.clone(),
                 processor_id,
-            })
-        } else {
-            None
+            }),
+            Ok(false) => Err(RegisterProcessorError::DuplicateId),
+            Err(_) => Err(RegisterProcessorError::PipelineTerminated),
         }
     }
 
@@ -443,3 +448,22 @@ impl MessageReceiver {
         }
     }
 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RegisterProcessorError {
+    /// パイプラインが終了している
+    PipelineTerminated,
+    /// プロセッサーIDが重複している
+    DuplicateId,
+}
+
+impl std::fmt::Display for RegisterProcessorError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::PipelineTerminated => write!(f, "Pipeline has terminated"),
+            Self::DuplicateId => write!(f, "Processor ID already registered"),
+        }
+    }
+}
+
+impl std::error::Error for RegisterProcessorError {}

--- a/src/media_pipeline.rs
+++ b/src/media_pipeline.rs
@@ -268,6 +268,20 @@ impl std::fmt::Display for ProcessorId {
     }
 }
 
+impl nojson::DisplayJson for ProcessorId {
+    fn fmt(&self, f: &mut nojson::JsonFormatter<'_, '_>) -> std::fmt::Result {
+        f.value(self.get())
+    }
+}
+
+impl<'text, 'raw> TryFrom<nojson::RawJsonValue<'text, 'raw>> for ProcessorId {
+    type Error = nojson::JsonParseError;
+
+    fn try_from(value: nojson::RawJsonValue<'text, 'raw>) -> Result<Self, Self::Error> {
+        value.try_into().map(Self)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct TrackId(String);
 
@@ -284,6 +298,20 @@ impl TrackId {
 impl std::fmt::Display for TrackId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
+    }
+}
+
+impl nojson::DisplayJson for TrackId {
+    fn fmt(&self, f: &mut nojson::JsonFormatter<'_, '_>) -> std::fmt::Result {
+        f.value(self.get())
+    }
+}
+
+impl<'text, 'raw> TryFrom<nojson::RawJsonValue<'text, 'raw>> for TrackId {
+    type Error = nojson::JsonParseError;
+
+    fn try_from(value: nojson::RawJsonValue<'text, 'raw>) -> Result<Self, Self::Error> {
+        value.try_into().map(Self)
     }
 }
 

--- a/src/media_pipeline.rs
+++ b/src/media_pipeline.rs
@@ -113,12 +113,12 @@ impl MediaPipeline {
         &mut self,
         processor_id: ProcessorId,
         track_id: TrackId,
-    ) -> Option<MessageSender> {
+    ) -> Result<MessageSender, PublishTrackError> {
         tracing::debug!("publish track: processor={processor_id}, track={track_id}");
 
         if !self.processors.contains(&processor_id) {
             tracing::warn!("attempt to publish track from unregistered processor: {processor_id}");
-            return None;
+            return Err(PublishTrackError::UnregisteredProcessor);
         }
 
         // トラックが存在しない場合は新規作成
@@ -131,7 +131,7 @@ impl MediaPipeline {
             tracing::warn!(
                 "publisher conflict for track: processor={processor_id}, track={track_id}"
             );
-            return None;
+            return Err(PublishTrackError::DuplicateTrackId);
         }
 
         let (command_tx, command_rx) = tokio::sync::mpsc::unbounded_channel();
@@ -142,7 +142,7 @@ impl MediaPipeline {
             let _ = command_tx.send(TrackCommand::AddSubscriber(subscriber_tx));
         }
 
-        Some(MessageSender {
+        Ok(MessageSender {
             rx: command_rx,
             txs: Vec::new(),
         })
@@ -214,7 +214,7 @@ impl MediaPipelineHandle {
                 pipeline_handle: self.clone(),
                 processor_id,
             }),
-            Ok(false) => Err(RegisterProcessorError::DuplicateId),
+            Ok(false) => Err(RegisterProcessorError::DuplicateProcessorId),
             Err(_) => Err(RegisterProcessorError::PipelineTerminated),
         }
     }
@@ -240,7 +240,7 @@ enum Command {
     PublishTrack {
         processor_id: ProcessorId,
         track_id: TrackId,
-        reply_tx: tokio::sync::oneshot::Sender<Option<MessageSender>>,
+        reply_tx: tokio::sync::oneshot::Sender<Result<MessageSender, PublishTrackError>>,
     },
     SubscribeTrack {
         processor_id: ProcessorId,
@@ -332,7 +332,10 @@ impl ProcessorHandle {
         &self.processor_id
     }
 
-    pub async fn publish_track(&self, track_id: TrackId) -> Option<MessageSender> {
+    pub async fn publish_track(
+        &self,
+        track_id: TrackId,
+    ) -> Result<MessageSender, PublishTrackError> {
         let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
         let command = Command::PublishTrack {
             processor_id: self.processor_id.clone(),
@@ -340,7 +343,10 @@ impl ProcessorHandle {
             reply_tx,
         };
         self.pipeline_handle.send(command);
-        reply_rx.await.ok()?
+        match reply_rx.await {
+            Ok(result) => result,
+            Err(_) => Err(PublishTrackError::PipelineTerminated),
+        }
     }
 
     pub fn subscribe_track(&self, track_id: TrackId) -> MessageReceiver {
@@ -482,16 +488,38 @@ pub enum RegisterProcessorError {
     /// パイプラインが終了している
     PipelineTerminated,
     /// プロセッサーIDが重複している
-    DuplicateId,
+    DuplicateProcessorId,
 }
 
 impl std::fmt::Display for RegisterProcessorError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::PipelineTerminated => write!(f, "Pipeline has terminated"),
-            Self::DuplicateId => write!(f, "Processor ID already registered"),
+            Self::DuplicateProcessorId => write!(f, "Processor ID already registered"),
         }
     }
 }
 
 impl std::error::Error for RegisterProcessorError {}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PublishTrackError {
+    /// パイプラインが終了している
+    PipelineTerminated,
+    /// トラックIDが重複している
+    DuplicateTrackId,
+    /// プロセッサーが未登録
+    UnregisteredProcessor,
+}
+
+impl std::fmt::Display for PublishTrackError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::PipelineTerminated => write!(f, "Pipeline has terminated"),
+            Self::DuplicateTrackId => write!(f, "Track ID already published"),
+            Self::UnregisteredProcessor => write!(f, "Processor is not registered"),
+        }
+    }
+}
+
+impl std::error::Error for PublishTrackError {}

--- a/src/subcommand_rtmp_inbound_endpoint.rs
+++ b/src/subcommand_rtmp_inbound_endpoint.rs
@@ -53,11 +53,14 @@ pub fn run(mut args: noargs::RawArgs) -> noargs::Result<()> {
             Default::default(),
         );
         pipeline_handle
-            .spawn_processor(crate::ProcessorId::new("rtmp_inbound"), |handle| {
-                endpoint.run(handle)
-            })
-            .await
-            .or_fail()?;
+            .spawn_processor(
+                crate::ProcessorId::new("rtmp_inbound"),
+                |handle| async move {
+                    endpoint.run(handle).await?;
+                    Ok::<(), crate::Error>(())
+                },
+            )
+            .await?;
 
         // MP4 Writer を起動
         let writer = crate::writer_mp4::Mp4Writer::new(
@@ -66,19 +69,24 @@ pub fn run(mut args: noargs::RawArgs) -> noargs::Result<()> {
             Some(AUDIO_STREAM_ID),
             Some(VIDEO_STREAM_ID),
         )
-        .or_fail()?;
+        .map_err(|e| crate::Error::new(e.to_string()))?;
         pipeline_handle
-            .spawn_processor(crate::ProcessorId::new("mp4_writer"), move |handle| {
-                writer.run(
-                    handle,
-                    Some(crate::TrackId::new(format!("{stream_name}_audio"))),
-                    Some(crate::TrackId::new(format!("{stream_name}_video"))),
-                )
-            })
-            .await
-            .or_fail()?;
+            .spawn_processor(
+                crate::ProcessorId::new("mp4_writer"),
+                move |handle| async move {
+                    writer
+                        .run(
+                            handle,
+                            Some(crate::TrackId::new(format!("{stream_name}_audio"))),
+                            Some(crate::TrackId::new(format!("{stream_name}_video"))),
+                        )
+                        .await?;
+                    Ok::<(), crate::Error>(())
+                },
+            )
+            .await?;
 
-        Ok::<(), orfail::Failure>(())
+        Ok::<(), crate::Error>(())
     });
 
     runtime.block_on(pipeline.run());

--- a/src/writer_mp4.rs
+++ b/src/writer_mp4.rs
@@ -360,7 +360,7 @@ impl Mp4Writer {
         handle: crate::ProcessorHandle,
         input_audio_track_id: Option<crate::TrackId>,
         input_video_track_id: Option<crate::TrackId>,
-    ) -> orfail::Result<()> {
+    ) -> crate::Result<()> {
         let mut audio_rx = input_audio_track_id.map(|id| handle.subscribe_track(id));
         let mut video_rx = input_video_track_id.map(|id| handle.subscribe_track(id));
 
@@ -392,7 +392,7 @@ impl Mp4Writer {
 
             in_progress = self
                 .handle_next_audio_and_video(audio_timestamp, video_timestamp)
-                .or_fail()?;
+                .map_err(|e| crate::Error::new(e.to_string()))?;
         }
 
         Ok(())


### PR DESCRIPTION
📝 合わせて `register_processor` を public にしている