### PR TITLE
{Audio,Video}Frame から duration フィールドを削除する

### DIFF
--- a/src/audio.rs
+++ b/src/audio.rs
@@ -84,7 +84,6 @@ pub struct AudioFrame {
     pub channels: Channels,
     pub sample_rate: SampleRate,
     pub timestamp: Duration,
-    pub duration: Duration,
     pub sample_entry: Option<SampleEntry>,
 }
 

--- a/src/audio_converter.rs
+++ b/src/audio_converter.rs
@@ -128,8 +128,6 @@ impl AudioConverter {
             self.reset();
         }
 
-        let duration =
-            duration_from_samples(interleaved.len(), target_channels, target_sample_rate)?;
         let preserve_sample_entry = target_format == frame.format
             && target_sample_rate == frame.sample_rate
             && target_channels == frame.channels;
@@ -140,7 +138,6 @@ impl AudioConverter {
             channels: target_channels,
             sample_rate: target_sample_rate,
             timestamp: frame.timestamp,
-            duration,
             sample_entry: if preserve_sample_entry {
                 frame.sample_entry.clone()
             } else {
@@ -236,23 +233,6 @@ fn parse_i16be_samples(frame: &AudioFrame) -> crate::Result<Vec<i16>> {
         .collect())
 }
 
-fn duration_from_samples(
-    sample_count: usize,
-    channels: Channels,
-    sample_rate: SampleRate,
-) -> crate::Result<Duration> {
-    let samples_per_channel = if channels.is_stereo() {
-        if !sample_count.is_multiple_of(2) {
-            return Err(crate::Error::new("invalid stereo audio sample count"));
-        }
-        sample_count / 2
-    } else {
-        sample_count
-    };
-
-    Ok(sample_rate.duration_from_samples(samples_per_channel as u64))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -274,7 +254,6 @@ mod tests {
             channels,
             sample_rate,
             timestamp: Duration::from_millis(100),
-            duration: Duration::from_millis(20),
             sample_entry: None,
         }
     }
@@ -337,7 +316,6 @@ mod tests {
 
         assert_eq!(output.sample_rate.get(), 48_000);
         assert!(!output.data.is_empty());
-        assert_ne!(output.duration, input.duration);
     }
 
     #[test]
@@ -357,7 +335,6 @@ mod tests {
 
         assert_eq!(output.sample_rate.get(), 32_000);
         assert!(!output.data.is_empty());
-        assert_ne!(output.duration, input.duration);
     }
 
     #[test]

--- a/src/audio_converter.rs
+++ b/src/audio_converter.rs
@@ -1,5 +1,3 @@
-use std::time::Duration;
-
 use crate::audio::{AudioFormat, AudioFrame, Channels, SampleRate};
 
 #[derive(Debug, Clone, Default)]
@@ -235,6 +233,8 @@ fn parse_i16be_samples(frame: &AudioFrame) -> crate::Result<Vec<i16>> {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use super::*;
 
     fn i16be(samples: &[i16]) -> Vec<u8> {

--- a/src/decoder_audio_toolbox.rs
+++ b/src/decoder_audio_toolbox.rs
@@ -98,7 +98,6 @@ impl AudioToolboxDecoder {
         }
         let samples_per_channel = decoded_samples.len() / usize::from(channels.get());
         let timestamp = sample_rate.duration_from_samples(self.total_output_samples);
-        let duration = sample_rate.duration_from_samples(samples_per_channel as u64);
         self.total_output_samples += samples_per_channel as u64;
 
         Ok(AudioFrame {
@@ -110,7 +109,6 @@ impl AudioToolboxDecoder {
             channels,
             sample_rate,
             timestamp,
-            duration,
             sample_entry: None,
         })
     }

--- a/src/decoder_fdk_aac.rs
+++ b/src/decoder_fdk_aac.rs
@@ -77,7 +77,6 @@ impl FdkAacDecoder {
                 channels: self.channels.unwrap_or(frame.channels),
                 sample_rate: self.sample_rate.unwrap_or(frame.sample_rate),
                 timestamp,
-                duration: Duration::from_secs(0),
                 sample_entry: None,
             })
         }
@@ -99,7 +98,6 @@ impl FdkAacDecoder {
         }
         let samples_per_channel = decoded_samples.len() / usize::from(channels.get());
         let timestamp = sample_rate.duration_from_samples(self.total_output_samples);
-        let duration = sample_rate.duration_from_samples(samples_per_channel as u64);
         self.total_output_samples += samples_per_channel as u64;
 
         Ok(AudioFrame {
@@ -111,7 +109,6 @@ impl FdkAacDecoder {
             channels,
             sample_rate,
             timestamp,
-            duration,
             sample_entry: None,
         })
     }

--- a/src/decoder_opus.rs
+++ b/src/decoder_opus.rs
@@ -36,7 +36,6 @@ impl OpusDecoder {
             channels: Channels::STEREO,
             sample_rate: SampleRate::HZ_48000,
             timestamp: frame.timestamp,
-            duration: frame.duration,
 
             // 生データにはサンプルエントリーは存在しない
             sample_entry: None,

--- a/src/encoder_audio_toolbox.rs
+++ b/src/encoder_audio_toolbox.rs
@@ -56,7 +56,6 @@ impl AudioToolboxEncoder {
         &mut self,
         encoded: shiguredo_audio_toolbox::EncodedFrame,
     ) -> AudioFrame {
-        let duration = Duration::from_secs(encoded.samples as u64) / SampleRate::HZ_48000.get();
         let timestamp =
             Duration::from_secs(self.total_encoded_samples) / SampleRate::HZ_48000.get();
         self.total_encoded_samples += encoded.samples as u64;
@@ -73,7 +72,6 @@ impl AudioToolboxEncoder {
             // エンコード結果を反映する
             data: encoded.data,
             timestamp,
-            duration,
         }
     }
 }

--- a/src/encoder_fdk_aac.rs
+++ b/src/encoder_fdk_aac.rs
@@ -57,7 +57,6 @@ impl FdkAacEncoder {
     }
 
     fn handle_encoded_frame(&mut self, encoded: shiguredo_fdk_aac::EncodedFrame) -> AudioFrame {
-        let duration = Duration::from_secs(encoded.samples as u64) / SampleRate::HZ_48000.get();
         let timestamp =
             Duration::from_secs(self.total_encoded_samples) / SampleRate::HZ_48000.get();
         self.total_encoded_samples += encoded.samples as u64;
@@ -74,7 +73,6 @@ impl FdkAacEncoder {
             // エンコード結果を反映する
             data: encoded.data,
             timestamp,
-            duration,
         }
     }
 }

--- a/src/encoder_libvpx.rs
+++ b/src/encoder_libvpx.rs
@@ -127,7 +127,6 @@ impl LibvpxEncoder {
                 width: frame.width() as usize,
                 height: frame.height() as usize,
                 timestamp: input_frame.timestamp,
-                duration: input_frame.duration,
             });
         }
 

--- a/src/encoder_nvcodec.rs
+++ b/src/encoder_nvcodec.rs
@@ -231,7 +231,6 @@ impl NvcodecEncoder {
                 width: input_frame.width,
                 height: input_frame.height,
                 timestamp: input_frame.timestamp,
-                duration: input_frame.duration,
                 sample_entry: self.sample_entry.take(),
             });
         }

--- a/src/encoder_openh264.rs
+++ b/src/encoder_openh264.rs
@@ -83,7 +83,6 @@ impl Openh264Encoder {
             width: frame.width,
             height: frame.height,
             timestamp: frame.timestamp,
-            duration: frame.duration,
             sample_entry,
         });
 

--- a/src/encoder_opus.rs
+++ b/src/encoder_opus.rs
@@ -50,7 +50,6 @@ impl OpusEncoder {
 
             // 入力の値をそのまま引きつぐ
             timestamp: frame.timestamp,
-            duration: frame.duration,
 
             // サンプルエントリーは途中で変わらないので、最初に一回だけ載せる
             sample_entry: self.sample_entry.take(),

--- a/src/encoder_svt_av1.rs
+++ b/src/encoder_svt_av1.rs
@@ -88,7 +88,6 @@ impl SvtAv1Encoder {
                 width: self.width.get(),
                 height: self.height.get(),
                 timestamp: input_frame.timestamp,
-                duration: input_frame.duration,
                 sample_entry: self.sample_entry.take(),
             });
         }

--- a/src/encoder_video_toolbox.rs
+++ b/src/encoder_video_toolbox.rs
@@ -154,7 +154,6 @@ impl VideoToolboxEncoder {
                 width: self.width.get(),
                 height: self.height.get(),
                 timestamp: input_frame.timestamp,
-                duration: input_frame.duration,
                 sample_entry,
             });
         }

--- a/src/file_reader_mp4.rs
+++ b/src/file_reader_mp4.rs
@@ -173,7 +173,6 @@ impl Mp4FileReader {
             channels: state.audio_channels,
             sample_rate: state.audio_sample_rate,
             timestamp: effective_timestamp,
-            duration,
             sample_entry: context.sample_entry,
         };
 
@@ -221,7 +220,6 @@ impl Mp4FileReader {
             width: state.video_width,
             height: state.video_height,
             timestamp: effective_timestamp,
-            duration,
             sample_entry: context.sample_entry,
         };
 

--- a/src/inbound_endpoint_srt.rs
+++ b/src/inbound_endpoint_srt.rs
@@ -860,7 +860,6 @@ impl SrtTsDemuxer {
             width: 0,
             height: 0,
             timestamp: relative_timestamp,
-            duration: Duration::ZERO,
             sample_entry: None, // Annex-B 入力では sample_entry は付与しない
         })))
     }
@@ -916,20 +915,12 @@ impl SrtTsDemuxer {
             let timestamp = timestamp_90khz_to_duration(pts.as_u64().saturating_add(pts_ticks));
             let base_timestamp = *self.base_audio_timestamp.get_or_insert(timestamp);
             let relative_timestamp = timestamp.saturating_sub(base_timestamp);
-            let duration = Duration::from_micros(
-                (1_000_000u64)
-                    .saturating_mul(1024)
-                    .checked_div(sample_rate as u64)
-                    .unwrap_or(0),
-            );
-
             samples.push(TsSample::Audio(crate::AudioFrame {
                 data: raw_data,
                 format: crate::audio::AudioFormat::Aac,
                 channels: crate::audio::Channels::from_u16(channels)?,
                 sample_rate: sample_rate_value,
                 timestamp: relative_timestamp,
-                duration,
                 sample_entry: None,
             }));
 

--- a/src/mixer_realtime_video.rs
+++ b/src/mixer_realtime_video.rs
@@ -238,16 +238,12 @@ impl VideoRealtimeMixerRunner {
         }
 
         let timestamp = frames_to_timestamp(self.frame_rate, self.output_frame_index);
-        let duration =
-            frames_to_timestamp(self.frame_rate, self.output_frame_index.saturating_add(1))
-                .saturating_sub(timestamp);
         self.output_frame_index = self.output_frame_index.saturating_add(1);
 
         let frame = compose_frame(
             self.canvas_width,
             self.canvas_height,
             timestamp,
-            duration,
             &self.draw_order,
             &self.states,
         )?;
@@ -453,7 +449,6 @@ fn compose_frame(
     canvas_width: usize,
     canvas_height: usize,
     timestamp: Duration,
-    duration: Duration,
     draw_order: &[DrawOrder],
     states: &HashMap<TrackId, InputTrackState>,
 ) -> crate::Result<VideoFrame> {
@@ -509,7 +504,6 @@ fn compose_frame(
         keyframe: true,
         format: VideoFormat::I420,
         timestamp,
-        duration,
         width: canvas_width,
         height: canvas_height,
         data: canvas.into_data(),
@@ -1256,14 +1250,7 @@ mod tests {
         let mut states = HashMap::new();
         states.insert(track_id, state);
 
-        let frame = compose_frame(
-            2,
-            2,
-            Duration::ZERO,
-            Duration::from_millis(40),
-            &draw_order,
-            &states,
-        )?;
+        let frame = compose_frame(2, 2, Duration::ZERO, &draw_order, &states)?;
 
         assert_eq!(frame.format, VideoFormat::I420);
         assert_eq!(frame.data[0], 100);
@@ -1279,7 +1266,6 @@ mod tests {
         let mut frame =
             VideoFrame::black(EvenUsize::truncating_new(64), EvenUsize::truncating_new(64));
         frame.timestamp = timestamp;
-        frame.duration = Duration::from_millis(40);
         frame
     }
 
@@ -1291,7 +1277,6 @@ mod tests {
             width: 2,
             height: 2,
             timestamp,
-            duration: Duration::from_millis(40),
             data: vec![y, y, y, y, 200, 200, alpha],
         }
     }

--- a/src/reader_mp4.rs
+++ b/src/reader_mp4.rs
@@ -147,7 +147,6 @@ impl Mp4VideoReader {
             width: self.width,
             height: self.height,
             timestamp,
-            duration,
         }))
     }
 }
@@ -282,7 +281,6 @@ impl Mp4AudioReader {
             channels: self.channels,
             sample_rate: self.sample_rate,
             timestamp,
-            duration,
         }))
     }
 }

--- a/src/reader_webm.rs
+++ b/src/reader_webm.rs
@@ -313,8 +313,6 @@ impl VideoTrackHeader {
 pub struct WebmAudioReader {
     reader: ElementReader<std::io::Take<BufReader<std::fs::File>>>,
     cluster_timestamp: Duration,
-    last_duration: Duration,
-    prev_audio_data: Option<AudioFrame>,
 
     pub current_input_file: Option<PathBuf>,
     pub codec: Option<CodecName>,
@@ -340,8 +338,6 @@ impl WebmAudioReader {
         Ok(Self {
             reader,
             cluster_timestamp: Duration::ZERO,
-            last_duration: Duration::ZERO,
-            prev_audio_data: None,
             current_input_file: Some(path.as_ref().to_path_buf()),
             codec: None,
             total_cluster_count: 0,
@@ -389,16 +385,12 @@ impl WebmAudioReader {
         let data = reader.read_raw_data()?;
 
         self.total_simple_block_count += 1;
-        self.total_track_duration = timestamp + self.last_duration;
+        self.total_track_duration = self.total_track_duration.max(timestamp);
 
         Ok(Some(AudioFrame {
             data,
             format: AudioFormat::Opus,
             timestamp,
-
-            // WebM には明示的な duration の情報は格納されていないので、
-            // 前後の音声データのタイムスタンプの差を設定する
-            duration: self.last_duration,
 
             // 以降のフィールドはデコーダーには参照されないのでダミー値を設定しておく
             sample_entry: None,
@@ -422,19 +414,12 @@ impl WebmAudioReader {
                 }
                 ID_SIMPLE_BLOCK => {
                     if let Some(current) = self.read_simple_block()? {
-                        let timestamp = current.timestamp;
-                        if let Some(mut prev) = self.prev_audio_data.replace(current) {
-                            // 尺を確定する
-                            prev.duration = timestamp.saturating_sub(prev.timestamp);
-                            self.last_duration = prev.duration;
-                            return Ok(Some(prev));
-                        }
+                        return Ok(Some(current));
                     }
                 }
                 ID_CUES => {
                     // メディアデータ格納部分を抜けたのでここで終了
-                    // 最後の AudioFrame が残っている場合には、まずそれを返す
-                    return Ok(self.prev_audio_data.take());
+                    return Ok(None);
                 }
                 id => {
                     return Err(crate::Error::new(format!(
@@ -459,8 +444,6 @@ pub struct WebmVideoReader {
     header: VideoTrackHeader,
     reader: ElementReader<std::io::Take<BufReader<std::fs::File>>>,
     cluster_timestamp: Duration,
-    last_duration: Duration,
-    prev_video_frame: Option<VideoFrame>,
     pub current_input_file: Option<PathBuf>,
     pub codec: Option<CodecName>,
     pub total_cluster_count: u64,
@@ -486,8 +469,6 @@ impl WebmVideoReader {
             header,
             reader,
             cluster_timestamp: Duration::ZERO,
-            last_duration: Duration::ZERO,
-            prev_video_frame: None,
             current_input_file: Some(path.as_ref().to_path_buf()),
             codec: None,
             total_cluster_count: 0,
@@ -528,19 +509,12 @@ impl WebmVideoReader {
                 }
                 ID_SIMPLE_BLOCK => {
                     if let Some(current) = self.read_simple_block()? {
-                        let timestamp = current.timestamp;
-                        if let Some(mut prev) = self.prev_video_frame.replace(current) {
-                            // 尺を確定する
-                            prev.duration = timestamp.saturating_sub(prev.timestamp);
-                            self.last_duration = prev.duration;
-                            return Ok(Some(prev));
-                        }
+                        return Ok(Some(current));
                     }
                 }
                 ID_CUES => {
                     // メディアデータ格納部分を抜けたのでここで終了
-                    // 最後の VideoFrame が残っている場合には、まずそれを返す
-                    return Ok(self.prev_video_frame.take());
+                    return Ok(None);
                 }
                 id => {
                     return Err(crate::Error::new(format!(
@@ -574,7 +548,7 @@ impl WebmVideoReader {
         let data = reader.read_raw_data()?;
 
         self.total_simple_block_count += 1;
-        self.total_track_duration = timestamp + self.last_duration;
+        self.total_track_duration = self.total_track_duration.max(timestamp);
         if self.codec.is_none()
             && let Some(name) = self.header.codec.codec_name()
         {
@@ -586,10 +560,6 @@ impl WebmVideoReader {
             format: self.header.codec,
             keyframe,
             timestamp,
-
-            // WebM には明示的な duration の情報は格納されていないので、
-            // 前後のフレームのタイムスタンプの差を設定する
-            duration: self.last_duration,
 
             // 以降のフィールドはデコーダーには参照されないのでダミー値を設定しておく
             width: 0,

--- a/src/reader_webm.rs
+++ b/src/reader_webm.rs
@@ -385,6 +385,9 @@ impl WebmAudioReader {
         let data = reader.read_raw_data()?;
 
         self.total_simple_block_count += 1;
+        // WebM は payload を解釈しないため、サンプル末尾の正確な duration はここでは求めない。
+        // そのため total_track_duration は「最終 SimpleBlock の開始時刻」を表す。
+        // (MP4 の total_track_duration とは意味が異なる)
         self.total_track_duration = self.total_track_duration.max(timestamp);
 
         Ok(Some(AudioFrame {
@@ -548,6 +551,9 @@ impl WebmVideoReader {
         let data = reader.read_raw_data()?;
 
         self.total_simple_block_count += 1;
+        // WebM は payload を解釈しないため、サンプル末尾の正確な duration はここでは求めない。
+        // そのため total_track_duration は「最終 SimpleBlock の開始時刻」を表す。
+        // (MP4 の total_track_duration とは意味が異なる)
         self.total_track_duration = self.total_track_duration.max(timestamp);
         if self.codec.is_none()
             && let Some(name) = self.header.codec.codec_name()

--- a/src/rtmp.rs
+++ b/src/rtmp.rs
@@ -162,7 +162,6 @@ pub struct RtmpIncomingFrameHandler {
     audio_sample_entry: Option<SampleEntry>,
     video_sample_entry: Option<SampleEntry>,
     received_video_keyframe: bool,
-    last_video_timestamp: Option<std::time::Duration>,
     rtmp_base_timestamp: Option<u32>,
     timestamp_offset: std::time::Duration,
 }
@@ -181,7 +180,6 @@ impl RtmpIncomingFrameHandler {
             audio_sample_entry: None,
             video_sample_entry: None,
             received_video_keyframe: false,
-            last_video_timestamp: None,
             rtmp_base_timestamp: None,
             timestamp_offset,
         }
@@ -240,7 +238,6 @@ impl RtmpIncomingFrameHandler {
             .ok_or_else(|| Error::new("audio codec info is not initialized"))?;
         Ok(Some(AudioFrame {
             timestamp: std::time::Duration::from_millis(adjusted_timestamp_ms),
-            duration: std::time::Duration::ZERO,
             format: codec_info.format,
             sample_rate: codec_info.sample_rate,
             channels: codec_info.channels,
@@ -301,27 +298,8 @@ impl RtmpIncomingFrameHandler {
         let (width, height) = crate::video_h264::extract_video_dimensions(sample_entry)
             .map_err(|e| e.with_context("failed to extract video dimensions"))?;
 
-        // durationを計算
-        //
-        // TODO: 将来的には VideoFrame 側で「duration が不明」を表現できるようにする
-        let duration = if let Some(last_ts) = self.last_video_timestamp {
-            if current_timestamp > last_ts {
-                current_timestamp - last_ts
-            } else {
-                // タイムスタンプがリセットされた場合は20msのデフォルト値
-                std::time::Duration::from_millis(20)
-            }
-        } else {
-            // 最初のフレームは20msで決め打ち
-            std::time::Duration::from_millis(20)
-        };
-
-        // 次のフレーム処理用に現在のタイムスタンプを記録
-        self.last_video_timestamp = Some(current_timestamp);
-
         Ok(Some(VideoFrame {
             timestamp: current_timestamp,
-            duration,
             keyframe: frame.frame_type == shiguredo_rtmp::VideoFrameType::KeyFrame,
             sample_entry: Some(sample_entry.clone()),
             format: crate::video::VideoFormat::H264,

--- a/src/sora_recording_mixer_audio.rs
+++ b/src/sora_recording_mixer_audio.rs
@@ -255,7 +255,6 @@ impl AudioMixer {
             format: AudioFormat::I16Be,
             channels: Channels::STEREO, // Hisui では音声は常にステレオとして扱う
             sample_rate: SampleRate::HZ_48000,
-            duration: MIXED_AUDIO_DATA_DURATION,
             sample_entry: None, // 生データにはサンプルエントリーはない
 
             // 以下は合成結果に応じた値

--- a/src/sora_recording_reader.rs
+++ b/src/sora_recording_reader.rs
@@ -60,6 +60,9 @@ impl AudioReader {
                 }
                 Some(Ok(mut frame)) => {
                     frame.timestamp += self.timestamp_offset;
+                    // WebM では total_track_duration が「最終 SimpleBlock の開始時刻」基準なので、
+                    // ここで計算する次ファイルのオフセットは末尾 duration 分だけ短くなることがある。
+                    // (Sora 録画用途としては許容する)
                     self.next_timestamp_offset =
                         self.timestamp_offset + self.inner.total_track_duration();
                     self.update_metrics_from_inner();
@@ -288,6 +291,9 @@ impl VideoReader {
                 }
                 Some(Ok(mut frame)) => {
                     frame.timestamp += self.timestamp_offset;
+                    // WebM では total_track_duration が「最終 SimpleBlock の開始時刻」基準なので、
+                    // ここで計算する次ファイルのオフセットは末尾 duration 分だけ短くなることがある。
+                    // (Sora 録画用途としては許容する)
                     self.next_timestamp_offset =
                         self.timestamp_offset + self.inner.total_track_duration();
                     self.update_metrics_from_inner();

--- a/src/sora_recording_reader.rs
+++ b/src/sora_recording_reader.rs
@@ -60,7 +60,8 @@ impl AudioReader {
                 }
                 Some(Ok(mut frame)) => {
                     frame.timestamp += self.timestamp_offset;
-                    self.next_timestamp_offset = frame.timestamp + frame.duration;
+                    self.next_timestamp_offset =
+                        self.timestamp_offset + self.inner.total_track_duration();
                     self.update_metrics_from_inner();
 
                     if !track_handle.send_media(MediaFrame::new_audio(frame)) {
@@ -219,6 +220,13 @@ impl AudioReaderInner {
             Self::Webm(r) => r.stats_mut().track_duration_offset = offset,
         }
     }
+
+    fn total_track_duration(&self) -> Duration {
+        match self {
+            Self::Mp4(r) => r.stats().total_track_duration,
+            Self::Webm(r) => r.stats().total_track_duration,
+        }
+    }
 }
 
 impl Iterator for AudioReaderInner {
@@ -280,7 +288,8 @@ impl VideoReader {
                 }
                 Some(Ok(mut frame)) => {
                     frame.timestamp += self.timestamp_offset;
-                    self.next_timestamp_offset = frame.timestamp + frame.duration;
+                    self.next_timestamp_offset =
+                        self.timestamp_offset + self.inner.total_track_duration();
                     self.update_metrics_from_inner();
 
                     if !track_handle.send_media(MediaFrame::new_video(frame)) {
@@ -436,6 +445,13 @@ impl VideoReaderInner {
         match self {
             Self::Mp4(r) => r.stats_mut().track_duration_offset = offset,
             Self::Webm(r) => r.stats_mut().track_duration_offset = offset,
+        }
+    }
+
+    fn total_track_duration(&self) -> Duration {
+        match self {
+            Self::Mp4(r) => r.stats().total_track_duration,
+            Self::Webm(r) => r.stats().total_track_duration,
         }
     }
 }

--- a/src/sora_recording_video_mixer.rs
+++ b/src/sora_recording_video_mixer.rs
@@ -599,12 +599,6 @@ impl VideoMixer {
         track_id: &TrackId,
         sample: Option<MediaFrame>,
     ) -> Result<()> {
-        let input_stream = self.input_streams.get_mut(track_id).ok_or_else(|| {
-            crate::Error::new(format!(
-                "unknown input track id for video mixer: {}",
-                track_id
-            ))
-        })?;
         if let Some(sample) = sample {
             // キューに要素を追加する
             let frame = sample.expect_video()?;
@@ -616,6 +610,12 @@ impl VideoMixer {
             }
 
             let mut duration = self.next_output_duration();
+            let input_stream = self.input_streams.get_mut(track_id).ok_or_else(|| {
+                crate::Error::new(format!(
+                    "unknown input track id for video mixer: {}",
+                    track_id
+                ))
+            })?;
             if let Some(prev) = input_stream.frame_queue.back_mut() {
                 let computed = frame.timestamp.saturating_sub(prev.start_timestamp());
                 if !computed.is_zero() {
@@ -635,6 +635,12 @@ impl VideoMixer {
                 ));
             self.stats.add_input_video_frame_count();
         } else {
+            let input_stream = self.input_streams.get_mut(track_id).ok_or_else(|| {
+                crate::Error::new(format!(
+                    "unknown input track id for video mixer: {}",
+                    track_id
+                ))
+            })?;
             input_stream.eos = true;
         }
         Ok(())

--- a/src/sora_recording_video_mixer.rs
+++ b/src/sora_recording_video_mixer.rs
@@ -204,6 +204,7 @@ pub struct VideoMixerSpec {
     pub trim_spans: TrimSpans,
     pub resize_filter_mode: shiguredo_libyuv::FilterMode,
     pub input_track_source_ids: HashMap<TrackId, SourceId>,
+    pub source_stop_timestamps: HashMap<SourceId, Duration>,
 }
 
 impl VideoMixerSpec {
@@ -215,6 +216,11 @@ impl VideoMixerSpec {
             trim_spans: layout.trim_spans.clone(),
             resize_filter_mode: shiguredo_libyuv::FilterMode::Box,
             input_track_source_ids: HashMap::new(),
+            source_stop_timestamps: layout
+                .sources
+                .iter()
+                .map(|(source_id, source)| (source_id.clone(), source.stop_timestamp))
+                .collect(),
         }
     }
 
@@ -372,7 +378,8 @@ impl VideoMixer {
                     .get(&id)
                     .cloned()
                     .unwrap_or_else(|| SourceId::new(id.get()));
-                (id, InputStream::new(source_id))
+                let stop_timestamp = spec.source_stop_timestamps.get(&source_id).copied();
+                (id, InputStream::new(source_id, stop_timestamp))
             })
             .collect();
         stats
@@ -641,6 +648,15 @@ impl VideoMixer {
                     track_id
                 ))
             })?;
+            if let (Some(frame), Some(stop_timestamp)) = (
+                input_stream.frame_queue.back_mut(),
+                input_stream.stop_timestamp,
+            ) {
+                let duration = stop_timestamp.saturating_sub(frame.start_timestamp());
+                if !duration.is_zero() {
+                    frame.set_duration(duration);
+                }
+            }
             input_stream.eos = true;
         }
         Ok(())
@@ -739,14 +755,16 @@ struct InputTrack {
 #[derive(Debug)]
 struct InputStream {
     source_id: SourceId,
+    stop_timestamp: Option<Duration>,
     eos: bool,
     frame_queue: VecDeque<ResizeCachedVideoFrame>,
 }
 
 impl InputStream {
-    fn new(source_id: SourceId) -> Self {
+    fn new(source_id: SourceId, stop_timestamp: Option<Duration>) -> Self {
         Self {
             source_id,
+            stop_timestamp,
             eos: false,
             frame_queue: VecDeque::new(),
         }

--- a/src/sora_recording_video_mixer.rs
+++ b/src/sora_recording_video_mixer.rs
@@ -606,6 +606,14 @@ impl VideoMixer {
         track_id: &TrackId,
         sample: Option<MediaFrame>,
     ) -> Result<()> {
+        let next_output_duration = sample.as_ref().map(|_| self.next_output_duration());
+        let input_stream = self.input_streams.get_mut(track_id).ok_or_else(|| {
+            crate::Error::new(format!(
+                "unknown input track id for video mixer: {}",
+                track_id
+            ))
+        })?;
+
         if let Some(sample) = sample {
             // キューに要素を追加する
             let frame = sample.expect_video()?;
@@ -620,13 +628,7 @@ impl VideoMixer {
             // 出力フレーム間隔 (next_output_duration) を使う。
             // その後、次フレーム到着時には timestamp 差分で上書きされ、
             // 最終フレームは EOS 時に stop_timestamp で補正されることがある。
-            let mut duration = self.next_output_duration();
-            let input_stream = self.input_streams.get_mut(track_id).ok_or_else(|| {
-                crate::Error::new(format!(
-                    "unknown input track id for video mixer: {}",
-                    track_id
-                ))
-            })?;
+            let mut duration = next_output_duration.expect("infallible");
             if let Some(prev) = input_stream.frame_queue.back_mut() {
                 let computed = frame.timestamp.saturating_sub(prev.start_timestamp());
                 if !computed.is_zero() {
@@ -646,12 +648,6 @@ impl VideoMixer {
                 ));
             self.stats.add_input_video_frame_count();
         } else {
-            let input_stream = self.input_streams.get_mut(track_id).ok_or_else(|| {
-                crate::Error::new(format!(
-                    "unknown input track id for video mixer: {}",
-                    track_id
-                ))
-            })?;
             if let (Some(frame), Some(stop_timestamp)) = (
                 input_stream.frame_queue.back_mut(),
                 input_stream.stop_timestamp,

--- a/src/sora_recording_video_mixer.rs
+++ b/src/sora_recording_video_mixer.rs
@@ -616,6 +616,10 @@ impl VideoMixer {
                 )));
             }
 
+            // 新規フレームの初期 duration は、比較対象がない場合のフォールバック値として
+            // 出力フレーム間隔 (next_output_duration) を使う。
+            // その後、次フレーム到着時には timestamp 差分で上書きされ、
+            // 最終フレームは EOS 時に stop_timestamp で補正されることがある。
             let mut duration = self.next_output_duration();
             let input_stream = self.input_streams.get_mut(track_id).ok_or_else(|| {
                 crate::Error::new(format!(

--- a/src/sora_recording_video_mixer.rs
+++ b/src/sora_recording_video_mixer.rs
@@ -29,14 +29,20 @@ const TIMESTAMP_GAP_ERROR_THRESHOLD: Duration = Duration::from_secs(24 * 60 * 60
 #[derive(Debug)]
 struct ResizeCachedVideoFrame {
     original: Arc<VideoFrame>,
+    duration: Duration,
     resized: Vec<((EvenUsize, EvenUsize), VideoFrame)>, // (width, height) => resized frame
     resize_filter_mode: shiguredo_libyuv::FilterMode,
 }
 
 impl ResizeCachedVideoFrame {
-    fn new(original: Arc<VideoFrame>, resize_filter_mode: shiguredo_libyuv::FilterMode) -> Self {
+    fn new(
+        original: Arc<VideoFrame>,
+        duration: Duration,
+        resize_filter_mode: shiguredo_libyuv::FilterMode,
+    ) -> Self {
         Self {
             original,
+            duration,
             resized: Vec::new(),
             resize_filter_mode,
         }
@@ -47,7 +53,15 @@ impl ResizeCachedVideoFrame {
     }
 
     fn end_timestamp(&self) -> Duration {
-        self.original.end_timestamp()
+        self.original.timestamp.saturating_add(self.duration)
+    }
+
+    fn duration(&self) -> Duration {
+        self.duration
+    }
+
+    fn set_duration(&mut self, duration: Duration) {
+        self.duration = duration;
     }
 
     fn resize(&mut self, width: EvenUsize, height: EvenUsize) -> crate::Result<&VideoFrame> {
@@ -492,7 +506,6 @@ impl VideoMixer {
 
             // 可変値
             timestamp,
-            duration,
             width: self.spec.resolution.width().get(),
             height: self.spec.resolution.height().get(),
             data: canvas.data,
@@ -602,10 +615,22 @@ impl VideoMixer {
                 )));
             }
 
+            let mut duration = self.next_output_duration();
+            if let Some(prev) = input_stream.frame_queue.back_mut() {
+                let computed = frame.timestamp.saturating_sub(prev.start_timestamp());
+                if !computed.is_zero() {
+                    prev.set_duration(computed);
+                    duration = computed;
+                } else {
+                    duration = prev.duration();
+                }
+            }
+
             input_stream
                 .frame_queue
                 .push_back(ResizeCachedVideoFrame::new(
                     frame,
+                    duration,
                     self.spec.resize_filter_mode,
                 ));
             self.stats.add_input_video_frame_count();
@@ -655,9 +680,9 @@ impl VideoMixer {
 
                 // 一定期間、入力の更新がない場合には、合成ではなく一つ前のフレームの尺を調整することで対応する
                 let duration = self.next_output_duration();
-                let last_frame = self.last_mixed_frame.as_mut().expect("infallible");
-
-                last_frame.duration += duration;
+                if self.last_mixed_frame.is_none() {
+                    continue;
+                }
                 self.stats.add_extended_video_frame_count();
                 // 出力フレーム数は増えないが、出力尺は伸びる。
                 self.stats.add_output_video_frame_duration(duration);

--- a/src/sora_recording_video_mixer.rs
+++ b/src/sora_recording_video_mixer.rs
@@ -701,12 +701,16 @@ impl VideoMixer {
                 }
 
                 // 一定期間、入力の更新がない場合には、合成ではなく一つ前のフレームの尺を調整することで対応する
-                let duration = self.next_output_duration();
                 if self.last_mixed_frame.is_none() {
+                    // 先頭フレームがまだない場合には、まず一度だけ通常合成を行って基準フレームを作る。
+                    // (このとき output 系の統計値も mix() 内で更新される)
+                    self.last_mixed_frame = Some(self.mix(now)?);
                     continue;
                 }
+                let duration = self.next_output_duration();
                 self.stats.add_extended_video_frame_count();
                 // 出力フレーム数は増えないが、出力尺は伸びる。
+                // VideoFrame には duration フィールドがないため、尺の延長は統計値と次フレーム timestamp 差分で表現する。
                 self.stats.add_output_video_frame_duration(duration);
 
                 continue;

--- a/src/source_png_file.rs
+++ b/src/source_png_file.rs
@@ -88,9 +88,6 @@ impl PngFileSource {
                 noacked_sent = 0;
             }
 
-            let next_timestamp =
-                frames_to_timestamp(self.frame_rate, frame_index.saturating_add(1));
-            let duration = next_timestamp.saturating_sub(timestamp);
             let frame = VideoFrame {
                 data: decoded.data.clone(),
                 format: VideoFormat::I420A,
@@ -98,7 +95,6 @@ impl PngFileSource {
                 width: decoded.width,
                 height: decoded.height,
                 timestamp,
-                duration,
                 sample_entry: None,
             };
 

--- a/src/source_video_device.rs
+++ b/src/source_video_device.rs
@@ -119,7 +119,6 @@ impl VideoDeviceSource {
             fps: self.fps.unwrap_or(default_config.fps),
         };
 
-        let default_duration = frame_duration_from_fps(config.fps);
         let (frame_tx, mut frame_rx) =
             tokio::sync::mpsc::unbounded_channel::<shiguredo_video_device::VideoFrameOwned>();
         let mut capture = shiguredo_video_device::VideoCapture::new(config, move |frame| {
@@ -130,13 +129,8 @@ impl VideoDeviceSource {
             .start()
             .map_err(|e| Error::new(format!("failed to start video capture session: {e}")))?;
 
-        let mut last_timestamp = None;
         while let Some(captured_frame) = frame_rx.recv().await {
-            let frame = convert_captured_frame_to_i420(
-                &captured_frame,
-                default_duration,
-                &mut last_timestamp,
-            )?;
+            let frame = convert_captured_frame_to_i420(&captured_frame)?;
             // TODO: send_syn() でペース調整に対応する
             if !output_video_sender.send_video(frame) {
                 break;
@@ -150,15 +144,8 @@ impl VideoDeviceSource {
     }
 }
 
-fn frame_duration_from_fps(fps: i32) -> Duration {
-    let fps = u64::try_from(fps).unwrap_or(1);
-    Duration::from_micros((1_000_000 / fps).max(1))
-}
-
 fn convert_captured_frame_to_i420(
     frame: &shiguredo_video_device::VideoFrameOwned,
-    default_duration: Duration,
-    last_timestamp: &mut Option<Duration>,
 ) -> Result<VideoFrame> {
     let width = usize::try_from(frame.width)
         .map_err(|_| Error::new(format!("invalid frame width: {}", frame.width)))?;
@@ -176,11 +163,6 @@ fn convert_captured_frame_to_i420(
     } else {
         Duration::from_micros(frame.timestamp_us as u64)
     };
-    let duration = match *last_timestamp {
-        Some(prev) if timestamp > prev => timestamp.saturating_sub(prev),
-        _ => default_duration,
-    };
-    *last_timestamp = Some(timestamp);
 
     match frame.pixel_format {
         shiguredo_video_device::PixelFormat::Nv12 => {
@@ -230,7 +212,6 @@ fn convert_captured_frame_to_i420(
                 width,
                 height,
                 timestamp,
-                duration,
                 sample_entry: None,
             };
             Ok(VideoFrame::new_i420(
@@ -270,7 +251,6 @@ fn convert_captured_frame_to_i420(
                 width,
                 height,
                 timestamp,
-                duration,
                 sample_entry: None,
             };
             Ok(VideoFrame::new_i420(
@@ -361,18 +341,13 @@ mod tests {
             timestamp_us: 1_000_000,
         };
 
-        let default_duration = Duration::from_millis(33);
-        let mut last_timestamp = None;
-        let frame =
-            convert_captured_frame_to_i420(&captured, default_duration, &mut last_timestamp)
-                .expect("convert");
+        let frame = convert_captured_frame_to_i420(&captured).expect("convert");
 
         assert_eq!(frame.format, crate::video::VideoFormat::I420);
         assert_eq!(frame.width, width);
         assert_eq!(frame.height, height);
         assert_eq!(frame.data, data);
         assert_eq!(frame.timestamp, Duration::from_secs(1));
-        assert_eq!(frame.duration, default_duration);
     }
 
     #[test]
@@ -396,11 +371,7 @@ mod tests {
             timestamp_us: 1_000_000,
         };
 
-        let default_duration = Duration::from_millis(33);
-        let mut last_timestamp = None;
-        let error =
-            convert_captured_frame_to_i420(&captured, default_duration, &mut last_timestamp)
-                .expect_err("must fail");
+        let error = convert_captured_frame_to_i420(&captured).expect_err("must fail");
 
         assert!(error.reason.contains("insufficient I420 data"));
     }

--- a/src/subcommand_inspect.rs
+++ b/src/subcommand_inspect.rs
@@ -19,7 +19,6 @@ const AUDIO_ENCODED_TRACK_ID: &str = "audio_encoded";
 const VIDEO_ENCODED_TRACK_ID: &str = "video_encoded";
 const AUDIO_DECODED_TRACK_ID: &str = "audio_decoded";
 const VIDEO_DECODED_TRACK_ID: &str = "video_decoded";
-const DEFAULT_SAMPLE_DURATION: Duration = Duration::from_millis(20);
 
 pub fn run(mut args: noargs::RawArgs) -> noargs::Result<()> {
     let decode: bool = noargs::flag("decode")
@@ -374,11 +373,11 @@ impl OutputPrinter {
         }
     }
 
-    fn estimate_duration(prev_timestamp: Duration, next_timestamp: Duration) -> Duration {
+    fn estimate_duration(prev_timestamp: Duration, next_timestamp: Duration) -> Option<Duration> {
         if next_timestamp > prev_timestamp {
-            next_timestamp.saturating_sub(prev_timestamp)
+            Some(next_timestamp.saturating_sub(prev_timestamp))
         } else {
-            DEFAULT_SAMPLE_DURATION
+            None
         }
     }
 
@@ -438,7 +437,7 @@ impl OutputPrinter {
                 }
                 if let Some(prev) = self.audio_samples.last_mut() {
                     let duration = Self::estimate_duration(prev.timestamp, audio_data.timestamp);
-                    prev.duration = Some(duration);
+                    prev.duration = duration;
                 }
                 self.audio_samples.push(AudioSampleInfo {
                     timestamp: audio_data.timestamp,
@@ -472,7 +471,7 @@ impl OutputPrinter {
                 }
                 if let Some(prev) = self.video_samples.last_mut() {
                     let duration = Self::estimate_duration(prev.timestamp, video_frame.timestamp);
-                    prev.duration = Some(duration);
+                    prev.duration = duration;
                 }
                 self.video_samples.push(VideoSampleInfo {
                     timestamp: video_frame.timestamp,

--- a/src/subcommand_inspect.rs
+++ b/src/subcommand_inspect.rs
@@ -19,6 +19,7 @@ const AUDIO_ENCODED_TRACK_ID: &str = "audio_encoded";
 const VIDEO_ENCODED_TRACK_ID: &str = "video_encoded";
 const AUDIO_DECODED_TRACK_ID: &str = "audio_decoded";
 const VIDEO_DECODED_TRACK_ID: &str = "video_decoded";
+const DEFAULT_SAMPLE_DURATION: Duration = Duration::from_millis(20);
 
 pub fn run(mut args: noargs::RawArgs) -> noargs::Result<()> {
     let decode: bool = noargs::flag("decode")
@@ -182,7 +183,7 @@ async fn setup_pipeline(
 #[derive(Debug)]
 struct AudioSampleInfo {
     timestamp: Duration,
-    duration: Duration,
+    duration: Option<Duration>,
     data_size: usize,
     decoded_data_size: Option<usize>,
 }
@@ -192,7 +193,7 @@ impl nojson::DisplayJson for AudioSampleInfo {
         f.set_indent_size(0);
         f.object(|f| {
             f.member("timestamp_us", self.timestamp.as_micros())?;
-            f.member("duration_us", self.duration.as_micros())?;
+            f.member("duration_us", self.duration.map(|v| v.as_micros() as u64))?;
             f.member("data_size", self.data_size)?;
             if let Some(v) = self.decoded_data_size {
                 f.member("decoded_data_size", v)?;
@@ -207,7 +208,7 @@ impl nojson::DisplayJson for AudioSampleInfo {
 #[derive(Debug)]
 struct VideoSampleInfo {
     timestamp: Duration,
-    duration: Duration,
+    duration: Option<Duration>,
     data_size: usize,
     keyframe: bool,
     codec_specific_info: Option<VideoCodecSpecificInfo>,
@@ -223,7 +224,7 @@ impl nojson::DisplayJson for VideoSampleInfo {
         f.set_indent_size(0);
         f.object(|f| {
             f.member("timestamp_us", self.timestamp.as_micros())?;
-            f.member("duration_us", self.duration.as_micros())?;
+            f.member("duration_us", self.duration.map(|v| v.as_micros() as u64))?;
             f.member("data_size", self.data_size)?;
             f.member("keyframe", self.keyframe)?;
             match &self.codec_specific_info {
@@ -373,6 +374,14 @@ impl OutputPrinter {
         }
     }
 
+    fn estimate_duration(prev_timestamp: Duration, next_timestamp: Duration) -> Duration {
+        if next_timestamp > prev_timestamp {
+            next_timestamp.saturating_sub(prev_timestamp)
+        } else {
+            DEFAULT_SAMPLE_DURATION
+        }
+    }
+
     async fn run(mut self, handle: crate::ProcessorHandle) -> Result<()> {
         let audio_encoded_track_id = self.audio_encoded_track_id.clone();
         let mut audio_encoded_track = handle.subscribe_track(audio_encoded_track_id.clone());
@@ -427,9 +436,13 @@ impl OutputPrinter {
                 if self.audio_codec.is_none() {
                     self.audio_codec = audio_data.format.codec_name();
                 }
+                if let Some(prev) = self.audio_samples.last_mut() {
+                    let duration = Self::estimate_duration(prev.timestamp, audio_data.timestamp);
+                    prev.duration = Some(duration);
+                }
                 self.audio_samples.push(AudioSampleInfo {
                     timestamp: audio_data.timestamp,
-                    duration: audio_data.duration,
+                    duration: None,
                     data_size: audio_data.data.len(),
                     decoded_data_size: None,
                 });
@@ -457,9 +470,13 @@ impl OutputPrinter {
                 if self.video_codec.is_none() {
                     self.video_codec = video_frame.format.codec_name();
                 }
+                if let Some(prev) = self.video_samples.last_mut() {
+                    let duration = Self::estimate_duration(prev.timestamp, video_frame.timestamp);
+                    prev.duration = Some(duration);
+                }
                 self.video_samples.push(VideoSampleInfo {
                     timestamp: video_frame.timestamp,
-                    duration: video_frame.duration,
+                    duration: None,
                     data_size: video_frame.data.len(),
                     keyframe: video_frame.keyframe,
                     codec_specific_info: VideoCodecSpecificInfo::new(&video_frame),
@@ -571,7 +588,7 @@ impl nojson::DisplayJson for OutputPrinter {
                     "audio_duration_us",
                     self.audio_samples
                         .iter()
-                        .map(|s| s.duration)
+                        .filter_map(|s| s.duration)
                         .sum::<Duration>()
                         .as_micros(),
                 )?;
@@ -584,7 +601,7 @@ impl nojson::DisplayJson for OutputPrinter {
                     "video_duration_us",
                     self.video_samples
                         .iter()
-                        .map(|s| s.duration)
+                        .filter_map(|s| s.duration)
                         .sum::<Duration>()
                         .as_micros(),
                 )?;

--- a/src/subcommand_inspect.rs
+++ b/src/subcommand_inspect.rs
@@ -584,6 +584,9 @@ impl nojson::DisplayJson for OutputPrinter {
             f.member("format", self.format)?;
             if let Some(c) = self.audio_codec {
                 f.member("audio_codec", c)?;
+                // 末尾サンプルの duration は次サンプルとの差分で算出できないため None のままにする。
+                // そのため合計 duration は filter_map で None を除外して集計する
+                // （最後のサンプル分は含まれない）。
                 f.member(
                     "audio_duration_us",
                     self.audio_samples
@@ -597,6 +600,9 @@ impl nojson::DisplayJson for OutputPrinter {
             }
             if let Some(c) = self.video_codec {
                 f.member("video_codec", c)?;
+                // 末尾サンプルの duration は次サンプルとの差分で算出できないため None のままにする。
+                // そのため合計 duration は filter_map で None を除外して集計する
+                // （最後のサンプル分は含まれない）。
                 f.member(
                     "video_duration_us",
                     self.video_samples

--- a/src/subscriber_whep.rs
+++ b/src/subscriber_whep.rs
@@ -12,8 +12,6 @@ use tokio::io::AsyncWriteExt;
 
 use crate::{Error, MessageSender, ProcessorHandle, TrackId};
 
-const DEFAULT_VIDEO_FRAME_DURATION: Duration = Duration::from_millis(33);
-
 #[derive(Debug, Clone)]
 pub struct WhepSubscriber {
     pub input_url: String,
@@ -145,34 +143,27 @@ impl WhepSession {
 
         let (frame_tx, frame_rx) = tokio::sync::mpsc::unbounded_channel::<crate::VideoFrame>();
         let (event_tx, event_rx) = tokio::sync::mpsc::unbounded_channel::<WhepEvent>();
-        let last_video_timestamp = Arc::new(Mutex::new(None::<Duration>));
-        let last_video_timestamp_for_sink = last_video_timestamp.clone();
-        let sink = VideoSinkBuilder::new(move |frame| {
-            match convert_webrtc_video_frame_to_i420(
-                frame,
-                &last_video_timestamp_for_sink,
-                DEFAULT_VIDEO_FRAME_DURATION,
-            ) {
-                Ok(video_frame) => {
-                    let _ = frame_tx.send(video_frame);
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        "failed to convert incoming WHEP video frame: {}",
-                        e.display()
-                    );
-                }
-            }
-        })
-        .build();
+        let sink =
+            VideoSinkBuilder::new(
+                move |frame| match convert_webrtc_video_frame_to_i420(frame) {
+                    Ok(video_frame) => {
+                        let _ = frame_tx.send(video_frame);
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            "failed to convert incoming WHEP video frame: {}",
+                            e.display()
+                        );
+                    }
+                },
+            )
+            .build();
         let video_track_state = Arc::new(Mutex::new(AttachedVideoTrackState {
             sink,
             current_track: None,
         }));
         let video_track_state_for_track = video_track_state.clone();
         let video_track_state_for_remove = video_track_state.clone();
-        let last_video_timestamp_for_track = last_video_timestamp.clone();
-        let last_video_timestamp_for_remove = last_video_timestamp.clone();
         let event_tx_for_conn = event_tx.clone();
         let event_tx_for_remove = event_tx.clone();
         let observer = PeerConnectionObserverBuilder::new()
@@ -213,9 +204,6 @@ impl WhepSession {
                     let wants = VideoSinkWants::new();
                     video_track.add_or_update_sink(&state.sink, &wants);
                     state.current_track = Some(video_track);
-                    if let Ok(mut ts) = last_video_timestamp_for_track.lock() {
-                        *ts = None;
-                    }
                 }
             })
             .on_remove_track(move |receiver| {
@@ -234,9 +222,6 @@ impl WhepSession {
                 {
                     if let Some(track) = state.current_track.take() {
                         track.remove_sink(&state.sink);
-                    }
-                    if let Ok(mut ts) = last_video_timestamp_for_remove.lock() {
-                        *ts = None;
                     }
                     let _ = event_tx_for_remove.send(WhepEvent::VideoTrackRemoved);
                 }
@@ -511,8 +496,6 @@ fn validate_input_url(input_url: &str) -> Result<(), String> {
 
 fn convert_webrtc_video_frame_to_i420(
     frame: shiguredo_webrtc::VideoFrameRef<'_>,
-    last_video_timestamp: &Arc<Mutex<Option<Duration>>>,
-    default_duration: Duration,
 ) -> crate::Result<crate::VideoFrame> {
     let buffer = frame.buffer();
     let width = usize::try_from(buffer.width())
@@ -528,16 +511,6 @@ fn convert_webrtc_video_frame_to_i420(
     } else {
         Duration::from_micros(frame.timestamp_us() as u64)
     };
-    let duration = if let Ok(mut last) = last_video_timestamp.lock() {
-        let duration = match *last {
-            Some(prev) if timestamp > prev => timestamp.saturating_sub(prev),
-            _ => default_duration,
-        };
-        *last = Some(timestamp);
-        duration
-    } else {
-        default_duration
-    };
 
     let y_stride = usize::try_from(buffer.stride_y())
         .map_err(|_| Error::new("incoming video frame Y stride is negative"))?;
@@ -552,7 +525,6 @@ fn convert_webrtc_video_frame_to_i420(
         width,
         height,
         timestamp,
-        duration,
         sample_entry: None,
     };
     Ok(crate::VideoFrame::new_i420(

--- a/src/video.rs
+++ b/src/video.rs
@@ -26,7 +26,6 @@ pub struct VideoFrame {
     pub width: usize,
     pub height: usize,
     pub timestamp: Duration,
-    pub duration: Duration,
     pub sample_entry: Option<SampleEntry>,
 }
 
@@ -62,7 +61,6 @@ impl VideoFrame {
         width: EvenUsize,
         height: EvenUsize,
         timestamp: Duration,
-        duration: Duration,
     ) -> crate::Result<Self> {
         let width_val = width.get();
         let height_val = height.get();
@@ -113,7 +111,6 @@ impl VideoFrame {
             width: width.get(),
             height: height.get(),
             timestamp,
-            duration,
             sample_entry: None,
         })
     }
@@ -126,7 +123,6 @@ impl VideoFrame {
             width: self.width,
             height: self.height,
             timestamp: self.timestamp,
-            duration: self.duration,
             sample_entry: None,
         }
     }
@@ -185,7 +181,6 @@ impl VideoFrame {
             width,
             height,
             timestamp: input_frame.timestamp,
-            duration: input_frame.duration,
         }
     }
 
@@ -327,7 +322,6 @@ impl VideoFrame {
             width,
             height,
             timestamp: input_frame.timestamp,
-            duration: input_frame.duration,
         })
     }
 
@@ -363,7 +357,6 @@ impl VideoFrame {
             width: actual_width,
             height: actual_height,
             timestamp: Duration::ZERO,
-            duration: Duration::ZERO,
             sample_entry: None,
         }
     }
@@ -386,7 +379,6 @@ impl VideoFrame {
             width: actual_width,
             height: actual_height,
             timestamp: Duration::ZERO,
-            duration: Duration::ZERO,
             sample_entry: None,
         }
     }
@@ -432,10 +424,6 @@ impl VideoFrame {
         let a_plane = &self.data[y_size + uv_size * 2..][..uv_size];
 
         Some((y_plane, u_plane, v_plane, a_plane))
-    }
-
-    pub fn end_timestamp(&self) -> Duration {
-        self.timestamp + self.duration
     }
 
     /// libyuv を使った YUV(I420) 画像リサイズ
@@ -549,7 +537,6 @@ impl VideoFrame {
             width: new_width.get(),
             height: new_height.get(),
             timestamp: self.timestamp,
-            duration: self.duration,
             sample_entry: self.sample_entry.clone(),
         };
         Ok(Some(resized))
@@ -868,7 +855,6 @@ mod tests {
             width: 4,
             height: 4,
             timestamp: Duration::ZERO,
-            duration: Duration::from_millis(40),
             data: vec![
                 // Y (4x4)
                 16, 16, 16, 16, 32, 32, 32, 32, 64, 64, 64, 64, 128, 128, 128, 128,

--- a/src/video_canvas.rs
+++ b/src/video_canvas.rs
@@ -178,7 +178,6 @@ mod tests {
         frame.data[y_size..][..uv_size].fill(64);
         frame.data[y_size + uv_size..][..uv_size].fill(192);
         frame.timestamp = Duration::from_millis(10);
-        frame.duration = Duration::from_millis(40);
         frame
     }
 }

--- a/src/writer_mp4.rs
+++ b/src/writer_mp4.rs
@@ -25,6 +25,7 @@ const TIMESCALE: NonZeroU32 = NonZeroU32::MIN.saturating_add(1_000_000 - 1);
 
 // 映像・音声混在時のチャンクの尺の最大値（映像か音声の片方だけの場合はチャンクは一つだけ）
 const MAX_CHUNK_DURATION: Duration = Duration::from_secs(10);
+// 末尾サンプルなどで前後関係から duration を再計算できない場合に使う既定値
 const DEFAULT_SAMPLE_DURATION: Duration = Duration::from_millis(20);
 
 // 入力がリアルタイムではなくファイルで、

--- a/src/writer_mp4.rs
+++ b/src/writer_mp4.rs
@@ -25,6 +25,7 @@ const TIMESCALE: NonZeroU32 = NonZeroU32::MIN.saturating_add(1_000_000 - 1);
 
 // 映像・音声混在時のチャンクの尺の最大値（映像か音声の片方だけの場合はチャンクは一つだけ）
 const MAX_CHUNK_DURATION: Duration = Duration::from_secs(10);
+const DEFAULT_SAMPLE_DURATION: Duration = Duration::from_millis(20);
 
 // 入力がリアルタイムではなくファイルで、
 // 映像・音声キューの件数差が大きい場合に、軽い音声側だけが先行して
@@ -199,6 +200,10 @@ pub struct Mp4Writer {
     input_video_track_id: Option<TrackId>,
     input_audio_queue: VecDeque<Arc<AudioFrame>>,
     input_video_queue: VecDeque<Arc<VideoFrame>>,
+    pending_audio_sample: Option<Arc<AudioFrame>>,
+    pending_video_frame: Option<Arc<VideoFrame>>,
+    last_audio_duration: Option<Duration>,
+    last_video_duration: Option<Duration>,
     appending_video_chunk: bool,
     stats: Mp4WriterStats,
 }
@@ -254,6 +259,10 @@ impl Mp4Writer {
             input_video_track_id,
             input_audio_queue: VecDeque::new(),
             input_video_queue: VecDeque::new(),
+            pending_audio_sample: None,
+            pending_video_frame: None,
+            last_audio_duration: None,
+            last_video_duration: None,
             appending_video_chunk: true,
             stats,
         })
@@ -270,13 +279,18 @@ impl Mp4Writer {
             .max(self.stats.total_video_track_duration())
     }
 
-    fn handle_next_audio_and_video(
-        &mut self,
-        audio_timestamp: Option<Duration>,
-        video_timestamp: Option<Duration>,
-    ) -> crate::Result<bool> {
+    fn handle_next_audio_and_video(&mut self) -> crate::Result<bool> {
+        self.flush_pending_audio_if_ready()?;
+        self.flush_pending_video_if_ready()?;
+
+        let audio_timestamp = self.input_audio_queue.front().map(|x| x.timestamp);
+        let video_timestamp = self.input_video_queue.front().map(|x| x.timestamp);
         match (audio_timestamp, video_timestamp) {
             (None, None) => {
+                if self.pending_audio_sample.is_some() || self.pending_video_frame.is_some() {
+                    // pending が残っている場合はフラッシュ後に再評価する
+                    return Ok(true);
+                }
                 // 全部の入力の処理が完了した
                 let finalized = self.muxer.finalize()?;
 
@@ -295,24 +309,24 @@ impl Mp4Writer {
             }
             (None, Some(_)) => {
                 // 残りは映像のみ
-                self.append_video_frame()?;
+                self.process_next_video_frame()?;
             }
             (Some(_), None) => {
                 // 残りは音声のみ
-                self.append_audio_data()?;
+                self.process_next_audio_sample()?;
             }
             (Some(audio_timestamp), Some(video_timestamp)) => {
                 if self.appending_video_chunk
                     && video_timestamp.saturating_sub(audio_timestamp) > MAX_CHUNK_DURATION
                 {
                     // 音声が一定以上遅れている場合は映像に追従する
-                    self.append_audio_data()?;
+                    self.process_next_audio_sample()?;
                 } else if !self.appending_video_chunk && video_timestamp > audio_timestamp {
                     // 一度音声追記モードに入った場合には、映像に追いつくまでは音声を追記し続ける
-                    self.append_audio_data()?;
+                    self.process_next_audio_sample()?;
                 } else {
                     // 音声との差が一定以内の場合は、映像の処理を進める
-                    self.append_video_frame()?;
+                    self.process_next_video_frame()?;
                 }
             }
         }
@@ -349,12 +363,23 @@ impl Mp4Writer {
         Ok(())
     }
 
-    fn append_video_frame(&mut self) -> crate::Result<()> {
-        // 次の入力を取り出す（これは常に成功する）
+    fn sample_duration_from_timestamps(
+        current_timestamp: Duration,
+        next_timestamp: Duration,
+        last_duration: Option<Duration>,
+    ) -> Duration {
+        if next_timestamp > current_timestamp {
+            next_timestamp.saturating_sub(current_timestamp)
+        } else {
+            last_duration.unwrap_or(DEFAULT_SAMPLE_DURATION)
+        }
+    }
+
+    fn append_pending_video_frame(&mut self, duration: Duration) -> crate::Result<()> {
         let frame = self
-            .input_video_queue
-            .pop_front()
-            .ok_or_else(|| crate::Error::new("video input queue is unexpectedly empty"))?;
+            .pending_video_frame
+            .take()
+            .ok_or_else(|| crate::Error::new("pending video frame is unexpectedly empty"))?;
 
         if self.stats.video_codec().is_none()
             && let Some(name) = frame.format.codec_name()
@@ -362,37 +387,29 @@ impl Mp4Writer {
             self.stats.set_video_codec(name);
         }
 
-        // ファイルへのデータ追記
         self.file.write_all(&frame.data)?;
         let data_offset = self.next_position;
-
-        // muxer へのサンプル登録
         let sample = shiguredo_mp4::mux::Sample {
             track_kind: shiguredo_mp4::TrackKind::Video,
             sample_entry: frame.sample_entry.clone(),
             keyframe: frame.keyframe,
             timescale: TIMESCALE,
-            duration: frame.duration.as_micros() as u32,
+            duration: duration.as_micros() as u32,
             data_offset,
             data_size: frame.data.len(),
         };
         self.muxer.append_sample(&sample)?;
-
-        // ポジションを更新
         self.next_position += frame.data.len() as u64;
-
-        self.stats
-            .add_video_sample(frame.data.len(), frame.duration);
-        self.appending_video_chunk = true;
+        self.stats.add_video_sample(frame.data.len(), duration);
+        self.last_video_duration = Some(duration);
         Ok(())
     }
 
-    fn append_audio_data(&mut self) -> crate::Result<()> {
-        // 次の入力を取り出す（これは常に成功する）
+    fn append_pending_audio_sample(&mut self, duration: Duration) -> crate::Result<()> {
         let data = self
-            .input_audio_queue
-            .pop_front()
-            .ok_or_else(|| crate::Error::new("audio input queue is unexpectedly empty"))?;
+            .pending_audio_sample
+            .take()
+            .ok_or_else(|| crate::Error::new("pending audio sample is unexpectedly empty"))?;
 
         if self.stats.audio_codec().is_none()
             && let Some(name) = data.format.codec_name()
@@ -400,27 +417,81 @@ impl Mp4Writer {
             self.stats.set_audio_codec(name);
         }
 
-        // ファイルへのデータ追記
         self.file.write_all(&data.data)?;
         let data_offset = self.next_position;
-
-        // muxer へのサンプル登録
         let sample = shiguredo_mp4::mux::Sample {
             track_kind: shiguredo_mp4::TrackKind::Audio,
             sample_entry: data.sample_entry.clone(),
             keyframe: true,
             timescale: TIMESCALE,
-            duration: data.duration.as_micros() as u32,
+            duration: duration.as_micros() as u32,
             data_offset,
             data_size: data.data.len(),
         };
         self.muxer.append_sample(&sample)?;
-
-        // ポジションを更新
         self.next_position += data.data.len() as u64;
+        self.stats.add_audio_sample(data.data.len(), duration);
+        self.last_audio_duration = Some(duration);
+        Ok(())
+    }
 
-        self.stats.add_audio_sample(data.data.len(), data.duration);
+    fn process_next_video_frame(&mut self) -> crate::Result<()> {
+        let frame = self
+            .input_video_queue
+            .pop_front()
+            .ok_or_else(|| crate::Error::new("video input queue is unexpectedly empty"))?;
+
+        if let Some(pending) = self.pending_video_frame.as_ref() {
+            let duration = Self::sample_duration_from_timestamps(
+                pending.timestamp,
+                frame.timestamp,
+                self.last_video_duration,
+            );
+            self.append_pending_video_frame(duration)?;
+        }
+        self.pending_video_frame = Some(frame);
+        self.appending_video_chunk = true;
+        Ok(())
+    }
+
+    fn process_next_audio_sample(&mut self) -> crate::Result<()> {
+        let data = self
+            .input_audio_queue
+            .pop_front()
+            .ok_or_else(|| crate::Error::new("audio input queue is unexpectedly empty"))?;
+
+        if let Some(pending) = self.pending_audio_sample.as_ref() {
+            let duration = Self::sample_duration_from_timestamps(
+                pending.timestamp,
+                data.timestamp,
+                self.last_audio_duration,
+            );
+            self.append_pending_audio_sample(duration)?;
+        }
+        self.pending_audio_sample = Some(data);
         self.appending_video_chunk = false;
+        Ok(())
+    }
+
+    fn flush_pending_audio_if_ready(&mut self) -> crate::Result<()> {
+        if self.input_audio_track_id.is_none()
+            && self.input_audio_queue.is_empty()
+            && self.pending_audio_sample.is_some()
+        {
+            let duration = self.last_audio_duration.unwrap_or(DEFAULT_SAMPLE_DURATION);
+            self.append_pending_audio_sample(duration)?;
+        }
+        Ok(())
+    }
+
+    fn flush_pending_video_if_ready(&mut self) -> crate::Result<()> {
+        if self.input_video_track_id.is_none()
+            && self.input_video_queue.is_empty()
+            && self.pending_video_frame.is_some()
+        {
+            let duration = self.last_video_duration.unwrap_or(DEFAULT_SAMPLE_DURATION);
+            self.append_pending_video_frame(duration)?;
+        }
         Ok(())
     }
 }
@@ -464,10 +535,7 @@ impl Mp4Writer {
                 });
             }
 
-            let audio_timestamp = self.input_audio_queue.front().map(|x| x.timestamp);
-            let video_timestamp = self.input_video_queue.front().map(|x| x.timestamp);
-
-            let in_progress = self.handle_next_audio_and_video(audio_timestamp, video_timestamp)?;
+            let in_progress = self.handle_next_audio_and_video()?;
 
             if !in_progress {
                 return Ok(WriterRunOutput::Finished);

--- a/tests/mixer_audio_test.rs
+++ b/tests/mixer_audio_test.rs
@@ -240,7 +240,7 @@ fn mix_three_sources_with_trim() -> hisui::Result<()> {
     Ok(())
 }
 
-/// AudioFrame.duration がソース毎に異なる場合のテスト
+/// 音声データ間隔がソース毎に異なる場合のテスト
 #[test]
 fn mix_three_sources_with_mixed_duration() -> hisui::Result<()> {
     // 100 ms のソースを三つ用意する
@@ -439,7 +439,6 @@ fn audio_data(
         channels: Channels::STEREO,
         sample_rate: SampleRate::HZ_48000,
         timestamp: source.start_timestamp + duration * i as u32,
-        duration,
         sample_entry: None,
     };
     MixerInput {

--- a/tests/mixer_video_test.rs
+++ b/tests/mixer_video_test.rs
@@ -69,8 +69,8 @@ fn mix_single_source() {
     );
 
     // 入力映像フレームを送信する: 500 ms のフレームを二つ
-    let input_frame0 = video_frame(size, ms(0), ms(500), 2);
-    let input_frame1 = video_frame(size, ms(500), ms(500), 4);
+    let input_frame0 = video_frame(size, ms(0), 2);
+    let input_frame1 = video_frame(size, ms(500), 4);
     mixer
         .process_input(VideoMixerInput::video_frame(
             input_stream_id.clone(),
@@ -147,8 +147,8 @@ fn mix_single_source_with_offset() {
 
     // 入力映像フレームを送信する: 500 ms のフレームを二つ
     // フレームのサイズは cell_size よりも大きいので合成時にリサイズされる
-    let input_frame0 = video_frame(output_size, ms(0), ms(500), 2);
-    let input_frame1 = video_frame(output_size, ms(500), ms(500), 4);
+    let input_frame0 = video_frame(output_size, ms(0), 2);
+    let input_frame1 = video_frame(output_size, ms(500), 4);
     mixer
         .process_input(VideoMixerInput::video_frame(
             input_stream_id.clone(),
@@ -273,8 +273,8 @@ fn single_source_multiple_regions() {
 
     // 入力映像フレームを送信する: 500 ms のフレームを二つ
     // リサイズを防ぐために cell_size を指定する
-    let input_frame0 = video_frame(cell_size, ms(0), ms(500), 2);
-    let input_frame1 = video_frame(cell_size, ms(500), ms(500), 4);
+    let input_frame0 = video_frame(cell_size, ms(0), 2);
+    let input_frame1 = video_frame(cell_size, ms(500), 4);
     mixer
         .process_input(VideoMixerInput::video_frame(
             input_stream_id.clone(),
@@ -402,7 +402,7 @@ fn single_source_multiple_regions_with_resize() {
 
     // 入力映像フレームを送信する
     // サイズは cell_size0 に合わせているので region1 での合成の際にはリサイズが発生する
-    let input_frame = video_frame(cell_size0, ms(0), ms(1000), 2);
+    let input_frame = video_frame(cell_size0, ms(0), 2);
     mixer
         .process_input(VideoMixerInput::video_frame(
             input_stream_id.clone(),
@@ -472,8 +472,8 @@ fn mix_with_trim() -> hisui::Result<()> {
     );
 
     // それぞれのソースで一つずつ入力映像フレームを送信する
-    let input_frame0 = video_frame(size, ms(0), ms(400), 2);
-    let input_frame1 = video_frame(size, ms(800), ms(200), 4);
+    let input_frame0 = video_frame(size, ms(0), 2);
+    let input_frame1 = video_frame(size, ms(800), 4);
     mixer
         .process_input(VideoMixerInput::video_frame(
             input_stream_id0.clone(),
@@ -550,8 +550,8 @@ fn mix_without_trim() -> hisui::Result<()> {
     );
 
     // それぞれのソースで一つずつ入力映像フレームを送信する
-    let input_frame0 = video_frame(size, ms(0), ms(400), 2);
-    let input_frame1 = video_frame(size, ms(800), ms(200), 4);
+    let input_frame0 = video_frame(size, ms(0), 2);
+    let input_frame1 = video_frame(size, ms(800), 4);
     mixer
         .process_input(VideoMixerInput::video_frame(
             input_stream_id0.clone(),
@@ -677,10 +677,10 @@ fn mix_multiple_cells() -> hisui::Result<()> {
     );
 
     // それぞれのソースで一つずつ入力映像フレームを送信する
-    let input_frame0 = video_frame(region_size, ms(0), ms(1000), 1);
-    let input_frame1 = video_frame(region_size, ms(400), ms(400), 2);
-    let input_frame2 = video_frame(region_size, ms(200), ms(800), 3);
-    let input_frame3 = video_frame(region_size, ms(0), ms(600), 4);
+    let input_frame0 = video_frame(region_size, ms(0), 1);
+    let input_frame1 = video_frame(region_size, ms(400), 2);
+    let input_frame2 = video_frame(region_size, ms(200), 3);
+    let input_frame3 = video_frame(region_size, ms(0), 4);
     mixer
         .process_input(VideoMixerInput::video_frame(
             input_stream_id0.clone(),
@@ -901,10 +901,10 @@ fn mix_multiple_cells_with_no_borders() -> hisui::Result<()> {
     );
 
     // それぞれのソースで一つずつ入力映像フレームを送信する
-    let input_frame0 = video_frame(region_size, ms(0), ms(1000), 1);
-    let input_frame1 = video_frame(region_size, ms(400), ms(400), 2);
-    let input_frame2 = video_frame(region_size, ms(200), ms(800), 3);
-    let input_frame3 = video_frame(region_size, ms(0), ms(600), 4);
+    let input_frame0 = video_frame(region_size, ms(0), 1);
+    let input_frame1 = video_frame(region_size, ms(400), 2);
+    let input_frame2 = video_frame(region_size, ms(200), 3);
+    let input_frame3 = video_frame(region_size, ms(0), 4);
     mixer
         .process_input(VideoMixerInput::video_frame(
             input_stream_id0.clone(),
@@ -1093,7 +1093,7 @@ fn non_yuv_video_input_error() -> hisui::Result<()> {
 
     // 適当に不正なフォーマットを指定して VideoFrame を送る
     // 入力映像フレームを送信する: 500 ms のフレームをひとつ
-    let mut input_frame = video_frame(size, ms(0), ms(500), 2);
+    let mut input_frame = video_frame(size, ms(0), 2);
     input_frame.format = VideoFormat::Av1;
     assert!(
         mixer
@@ -1219,7 +1219,7 @@ fn source(id: usize, start_timestamp: Duration, stop_timestamp: Duration) -> Sou
     }
 }
 
-fn video_frame(size: Size, timestamp: Duration, _duration: Duration, grayscale: u8) -> VideoFrame {
+fn video_frame(size: Size, timestamp: Duration, grayscale: u8) -> VideoFrame {
     let y_size = size.width * size.height;
     let uv_size = (size.width * size.height) / 4 * 2;
     VideoFrame {

--- a/tests/mixer_video_test.rs
+++ b/tests/mixer_video_test.rs
@@ -93,7 +93,6 @@ fn mix_single_source() {
         assert_eq!(frame.width, size.width);
         assert_eq!(frame.height, size.height);
         assert_eq!(frame.timestamp, OUTPUT_FRAME_DURATION * i as u32);
-        assert_eq!(frame.duration, OUTPUT_FRAME_DURATION);
 
         if i < 3 {
             // ここまでは最初の入力フレームのデータが使われる
@@ -172,7 +171,6 @@ fn mix_single_source_with_offset() {
         assert_eq!(frame.width, output_size.width);
         assert_eq!(frame.height, output_size.height);
         assert_eq!(frame.timestamp, OUTPUT_FRAME_DURATION * i as u32);
-        assert_eq!(frame.duration, OUTPUT_FRAME_DURATION);
 
         if i < 3 {
             // ここまでは最初の入力フレームのデータが使われる
@@ -299,7 +297,6 @@ fn single_source_multiple_regions() {
         assert_eq!(frame.width, output_size.width);
         assert_eq!(frame.height, output_size.height);
         assert_eq!(frame.timestamp, OUTPUT_FRAME_DURATION * i as u32);
-        assert_eq!(frame.duration, OUTPUT_FRAME_DURATION);
 
         if i < 3 {
             // ここまでは最初の入力フレームのデータが使われる
@@ -425,7 +422,6 @@ fn single_source_multiple_regions_with_resize() {
         assert_eq!(frame.width, output_size.width);
         assert_eq!(frame.height, output_size.height);
         assert_eq!(frame.timestamp, OUTPUT_FRAME_DURATION * i as u32);
-        assert_eq!(frame.duration, OUTPUT_FRAME_DURATION);
 
         // 共有ソースのリサイズによって想定外の影響で合成結果が変わっていないかを確認
         assert_eq!(frame.data, first_frame.data);
@@ -1223,7 +1219,7 @@ fn source(id: usize, start_timestamp: Duration, stop_timestamp: Duration) -> Sou
     }
 }
 
-fn video_frame(size: Size, timestamp: Duration, duration: Duration, grayscale: u8) -> VideoFrame {
+fn video_frame(size: Size, timestamp: Duration, _duration: Duration, grayscale: u8) -> VideoFrame {
     let y_size = size.width * size.height;
     let uv_size = (size.width * size.height) / 4 * 2;
     VideoFrame {
@@ -1235,7 +1231,6 @@ fn video_frame(size: Size, timestamp: Duration, duration: Duration, grayscale: u
         width: size.width,
         height: size.height,
         timestamp,
-        duration,
         sample_entry: None,
     }
 }

--- a/tests/reader_webm_test.rs
+++ b/tests/reader_webm_test.rs
@@ -2,18 +2,28 @@ use hisui::reader_webm::{WebmAudioReader, WebmVideoReader};
 
 #[test]
 fn webm_audio_reader_test() -> hisui::Result<()> {
-    let reader = WebmAudioReader::new("testdata/archive-black-silent.webm")?;
-    for audio_data in reader {
-        audio_data?;
+    let mut reader = WebmAudioReader::new("testdata/archive-black-silent.webm")?;
+    let mut last_timestamp = None;
+    for audio_data in reader.by_ref() {
+        let audio_data = audio_data?;
+        last_timestamp = Some(audio_data.timestamp);
+    }
+    if let Some(last_timestamp) = last_timestamp {
+        assert_eq!(reader.stats().total_track_duration, last_timestamp);
     }
     Ok(())
 }
 
 #[test]
 fn webm_video_reader_test() -> hisui::Result<()> {
-    let reader = WebmVideoReader::new("testdata/archive-black-silent.webm")?;
-    for video_frame in reader {
-        video_frame?;
+    let mut reader = WebmVideoReader::new("testdata/archive-black-silent.webm")?;
+    let mut last_timestamp = None;
+    for video_frame in reader.by_ref() {
+        let video_frame = video_frame?;
+        last_timestamp = Some(video_frame.timestamp);
+    }
+    if let Some(last_timestamp) = last_timestamp {
+        assert_eq!(reader.stats().total_track_duration, last_timestamp);
     }
     Ok(())
 }

--- a/tests/writer_mp4_tests.rs
+++ b/tests/writer_mp4_tests.rs
@@ -496,7 +496,6 @@ fn audio_data(source: &SourceInfo, i: usize, duration: Duration) -> AudioFrame {
         channels: Channels::STEREO,
         sample_rate: SampleRate::HZ_48000,
         timestamp: source.start_timestamp + duration * i as u32,
-        duration,
         sample_entry: if i == 0 {
             // 中身はなんでもいい
             Some(SampleEntry::Unknown(UnknownBox {
@@ -518,7 +517,6 @@ fn video_frame(source: &SourceInfo, i: usize, duration: Duration) -> VideoFrame 
         width: EvenUsize::MIN_CELL_SIZE.get(),
         height: EvenUsize::MIN_CELL_SIZE.get(),
         timestamp: source.start_timestamp + duration * i as u32,
-        duration,
         sample_entry: if i == 0 {
             // 中身はなんでもいい
             Some(SampleEntry::Unknown(UnknownBox {


### PR DESCRIPTION
モチベーション:
- timestamp と情報が重複している（最終フレームは例外）
- mp4 以外のフォーマット・プロトコルでは明示的に duration 情報を保持していないので、それを計算しようとすると 1 フレーム分の遅延が入力側で増えてリアルタイム処理と相性が悪い
- 出力側も mp4 以外は duration 情報が不要なので、それなら mp4 writer で計算した方がいい